### PR TITLE
Update dependency versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,18 +14,14 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
+  build-gradle-project:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-    - name: Build with Gradle
-      uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
-      with:
-        arguments: build
+      - name: Checkout project sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # so that spotless can ratchet; see https://github.com/diffplug/spotless/issues/710
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Run build with Gradle Wrapper
+        run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 
 plugins {
     id 'application'
-    id 'com.diffplug.spotless' version '6.0.5'
-    id 'org.checkerframework' version '0.6.6'
+    id 'com.diffplug.spotless' version '6.18.0'
+    id 'org.checkerframework' version '0.6.27'
     id("net.ltgt.errorprone") version "2.0.2"
     id 'com.adarshr.test-logger' version '3.1.0'
 }
@@ -67,9 +67,8 @@ spotless {
         endWithNewline()
     }
     java {
-        // don't need to set target, it is inferred from java
-        // apply a specific flavor of google-java-format
-        googleJavaFormat('1.12.0').reflowLongStrings()
+        googleJavaFormat().reflowLongStrings()
+        formatAnnotations()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Tue Dec 28 11:55:55 EST 2021
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
This should let us build Specimin with a modern JDK, and also hopefully fix the issue @LoiNguyenCS is seeing with Spotless, by updating it to the latest version