### PR TITLE
update codes to fix ashe

### DIFF
--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -268,7 +268,7 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
       }
       if (call.getScope().isPresent()) {
         Expression scope = call.getScope().get();
-        // if the scope of a method is called by a field, the type of that scope will be NameExpr.
+        // if the scope of a method call is a field, the type of that scope will be NameExpr.
         if (scope instanceof NameExpr) {
           NameExpr expression = call.getScope().get().asNameExpr();
           updateUsedElementWithPotentialFieldNameExpr(expression);

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -267,9 +267,8 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
         usedClass.add(methodReturnType.asReferenceType().getQualifiedName());
       }
       if (call.getScope().isPresent()) {
-        // the scope of a method will always be a NameExpr, while that NameExpr might be a field,
-        // variable, or a class.
         Expression scope = call.getScope().get();
+        // if the scope of a method is called by a field, the type of that scope will be NameExpr.
         if (scope instanceof NameExpr) {
           NameExpr expression = call.getScope().get().asNameExpr();
           updateUsedElementWithPotentialFieldNameExpr(expression);
@@ -348,8 +347,8 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   }
 
   /**
-   * Given a NameExpr instance that could be a field, this method will update the used elements,
-   * classes and members, if that NameExpr is a field.
+   * Given a NameExpr instance, this method will update the used elements, classes and members if
+   * that NameExpr is a field.
    *
    * @param expr a field access expression inside target methods
    */

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -590,11 +590,14 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       updateClassSetWithQualifiedStaticMethodCall(
           methodFullyQualifiedCall, getArgumentsFromMethodCall(method));
     }
-
-    this.gotException =
-        calledByAnUnsolvedSymbol(method)
+    boolean needToSetException =
+        !canBeSolved(method)
+            || calledByAnUnsolvedSymbol(method)
             || calledByAnIncompleteSyntheticClass(method)
             || isAnUnsolvedStaticMethodCalledByAQualifiedClassName(method);
+    if (needToSetException) {
+      this.gotException = true;
+    }
     return super.visit(method, p);
   }
 

--- a/src/test/java/org/checkerframework/specimin/MethodCalledByFieldTest.java
+++ b/src/test/java/org/checkerframework/specimin/MethodCalledByFieldTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks if Specimin will work correctly if inside target methods, there is a method call
+ * that is called by a field.
+ */
+public class MethodCalledByFieldTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "methodcalledbyfield",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#test()"});
+  }
+}

--- a/src/test/resources/methodcalledbyfield/expected/com/example/Simple.java
+++ b/src/test/resources/methodcalledbyfield/expected/com/example/Simple.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.math.Calculator;
+
+class Simple {
+
+    static final Calculator theField = null;
+
+    void test() {
+        int x = theField.doMultiplication(1, 2);
+    }
+}

--- a/src/test/resources/methodcalledbyfield/expected/org/math/Calculator.java
+++ b/src/test/resources/methodcalledbyfield/expected/org/math/Calculator.java
@@ -1,0 +1,8 @@
+package org.math;
+
+public class Calculator {
+
+    public int doMultiplication(int parameter0, int parameter1) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/methodcalledbyfield/input/com/example/Simple.java
+++ b/src/test/resources/methodcalledbyfield/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.math.Calculator;
+
+class Simple {
+    static final Calculator theField = new Calculator();
+    void test() {
+        int x = theField.doMultiplication(1, 2);
+    }
+}


### PR DESCRIPTION
This PR should fix the remaining problems with #41. Two changes that this PR makes are:

1. Add codes to update used elements (classes and methods) for method calls that are called by fields in `TargetMethodFinderVisitor`.
2. Have a more precise way to update `gotException` in `UnsolvedSymbolVisitor`.