### PR TITLE
add codes and tests for primitive array

### DIFF
--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -325,9 +325,11 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
         usedMembers.add(fullNameOfClass + "#" + expr.getName().asString());
         usedClass.add(fullNameOfClass);
         usedClass.add(expr.resolve().getType().describe());
-      }
-      // when the type is a primitive array, we will have an UnsupportedOperationException
-      catch (UnsolvedSymbolException | UnsupportedOperationException e) {
+      } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
+        // when the type is a primitive array, we will have an UnsupportedOperationException
+        if (e instanceof UnsupportedOperationException) {
+          updateUsedElementWithPotentialFieldNameExpr(expr.getScope().asNameExpr());
+        }
         // if the a field is accessed in the form of a fully-qualified path, such as
         // org.example.A.b, then other components in the path apart from the class name and field
         // name, such as org and org.example, will also be considered as FieldAccessExpr.

--- a/src/test/java/org/checkerframework/specimin/PrimitiveArrayTest.java
+++ b/src/test/java/org/checkerframework/specimin/PrimitiveArrayTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * This test checks if Specimin can handle fields of type primitive array.
+ */
+public class PrimitiveArrayTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "primitivearray",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/primitivearray/expected/com/example/Simple.java
+++ b/src/test/resources/primitivearray/expected/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+class Simple {
+
+    static final byte[] VALUES = null;
+
+    void bar() {
+        int length = VALUES.length;
+    }
+}

--- a/src/test/resources/primitivearray/input/com/example/Simple.java
+++ b/src/test/resources/primitivearray/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+class Simple {
+
+    static final byte[] VALUES = new byte[];
+    // Target method.
+    void bar() {
+        int length = VALUES.length;
+    }
+}


### PR DESCRIPTION
Professor,

This is a simple PR for Specimin to handle fields with primitive array types. For some reasons, JavaParser will throw an exception if we try to resolve fields with primitive array types, but it does not have any problems resolving methods with that same type.