### PR TITLE
Refactor how type variables are handled by UnsolvedClass

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedClass.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClass.java
@@ -41,25 +41,33 @@ public class UnsolvedClass {
   private boolean isExceptionType = false;
 
   /**
-   * Create an instance of UnsolvedClass
+   * Create an instance of UnsolvedClass. This constructor correctly splits apart the class name and
+   * any generics attached to it.
    *
-   * @param className the name of the class
+   * @param className the name of the class, possibly followed by a set of type arguments
    * @param packageName the name of the package
    */
-  public UnsolvedClass(@ClassGetSimpleName String className, String packageName) {
+  public UnsolvedClass(String className, String packageName) {
     this(className, packageName, false);
   }
 
   /**
    * Create an instance of UnsolvedClass
    *
-   * @param className the name of the class
+   * @param className the simple name of the class, possibly followed by a set of type arguments
    * @param packageName the name of the package
    * @param isException does the class represents an exception?
    */
-  public UnsolvedClass(
-      @ClassGetSimpleName String className, String packageName, boolean isException) {
-    this.className = className;
+  public UnsolvedClass(String className, String packageName, boolean isException) {
+    if (className.contains("<")) {
+      @SuppressWarnings("signature") // removing the <> makes this a true simple name
+      @ClassGetSimpleName String classNameWithoutAngleBrackets = className.substring(0, className.indexOf('<'));
+      this.className = classNameWithoutAngleBrackets;
+    } else {
+      @SuppressWarnings("signature") // no angle brackets means this is a true simple name
+      @ClassGetSimpleName String classNameWithoutAngleBrackets = className;
+      this.className = classNameWithoutAngleBrackets;
+    }
     this.methods = new LinkedHashSet<>();
     this.packageName = packageName;
     this.classFields = new LinkedHashSet<>();
@@ -76,25 +84,12 @@ public class UnsolvedClass {
   }
 
   /**
-   * Get the name of this class.
+   * Get the name of this class (note: without any generic type variables).
    *
    * @return the name of the class
    */
   public @ClassGetSimpleName String getClassName() {
     return className;
-  }
-
-  /**
-   * This method returns the name of this class without the generic types.
-   *
-   * @return name of the class without the generic types.
-   */
-  public String getBasicClassName() {
-    int indexOfGenericType = className.indexOf("<");
-    if (indexOfGenericType == -1) {
-      return className;
-    }
-    return className.substring(0, indexOfGenericType);
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -724,14 +724,11 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         return super.visit(typeExpr, p);
       } else if (isAClassPath(typeRawName)) {
         String packageName = typeRawName.substring(0, typeRawName.lastIndexOf("."));
-        @SuppressWarnings("signature") // since this is the last element of a class path
-        @ClassGetSimpleName String className = typeRawName.substring(typeRawName.lastIndexOf(".") + 1);
+        String className = typeRawName.substring(typeRawName.lastIndexOf(".") + 1);
         classToUpdate = new UnsolvedClass(className, packageName);
       } else {
-        @SuppressWarnings("signature") // since it is not in a fully qualifed format
-        @ClassGetSimpleName String className = typeRawName;
-        String packageName = classAndPackageMap.getOrDefault(className, currentPackage);
-        classToUpdate = new UnsolvedClass(className, packageName);
+        String packageName = classAndPackageMap.getOrDefault(typeRawName, currentPackage);
+        classToUpdate = new UnsolvedClass(typeRawName, packageName);
       }
       classToUpdate.setNumberOfTypeVariables(numberOfArguments);
       updateMissingClass(classToUpdate);
@@ -1522,7 +1519,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     String classPackage = missedClass.getPackageName();
     String classDirectory = classPackage.replace(".", "/");
     String filePathStr =
-        this.rootDirectory + classDirectory + "/" + missedClass.getBasicClassName() + ".java";
+        this.rootDirectory + classDirectory + "/" + missedClass.getClassName() + ".java";
     Path filePath = Path.of(filePathStr);
     try {
       Files.delete(filePath);
@@ -1544,7 +1541,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     String classPackage = missedClass.getPackageName();
     String classDirectory = classPackage.replace(".", "/");
     String filePathStr =
-        this.rootDirectory + classDirectory + "/" + missedClass.getBasicClassName() + ".java";
+        this.rootDirectory + classDirectory + "/" + missedClass.getClassName() + ".java";
     Path filePath = Paths.get(filePathStr);
     createdClass.add(filePath);
     try {


### PR DESCRIPTION
This simplifies the API and gives me confidence that `getClassName` really is the simple class name.

I made these changes as part of my investigation into #87, but this PR does **not** fix #87.