### PR TITLE
Don't print type variable signature in name of fields

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1132,6 +1132,10 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   public void updateSyntheticClassWithNonStaticFields(FieldAccessExpr field) {
     Expression caller = field.getScope();
     String fullyQualifiedClassName = caller.calculateResolvedType().describe();
+    int indexOfAngleBracket = fullyQualifiedClassName.indexOf('<');
+    if (indexOfAngleBracket != -1) {
+      fullyQualifiedClassName = fullyQualifiedClassName.substring(0, indexOfAngleBracket);
+    }
     String fieldQualifedSignature = fullyQualifiedClassName + "." + field.getNameAsString();
     updateClassSetWithQualifiedFieldSignature(fieldQualifedSignature, false, false);
   }


### PR DESCRIPTION
I confirmed on the full test case for #87 that this fixes the reported problem with missing classes like this one that have a type variable signature in the type of a field:
```
package org.checkerframework.dataflow.analysis;
public class OrgCheckerframeworkDataflowAnalysisAbstractAnalysis<V, S, T>CurrentTreeType {
}
```

This PR removes the "<V, S, T>" from this field's type. Unfortunately, this still doesn't fix #87.