### PR TITLE
Implement equality checks for UnsolvedMethod based on the JLS rules

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
@@ -1,6 +1,8 @@
 package org.checkerframework.specimin;
 
 import java.util.List;
+import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * An UnsolvedMethod instance is a representation of a method that can not be solved by
@@ -17,8 +19,8 @@ public class UnsolvedMethod {
   private String returnType;
 
   /**
-   * The list of parameters of the method. (Right now we won't touch it until the new variant of
-   * SymbolSolver is available)
+   * The list of the types of the parameters of the method. (Right now we won't touch it until the
+   * new variant of SymbolSolver is available)
    */
   private List<String> parameterList;
 
@@ -69,6 +71,24 @@ public class UnsolvedMethod {
   /** Set isStatic to true */
   public void setStatic() {
     isStatic = true;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (!(o instanceof UnsolvedMethod)) {
+      return false;
+    }
+    UnsolvedMethod other = (UnsolvedMethod) o;
+    // This set of fields is based on the JLS' overloading rules, which
+    // permit an overload if any of the name, return type, or parameter types differ.
+    return other.returnType.equals(this.returnType)
+        && other.name.equals(this.name)
+        && other.parameterList.equals(parameterList);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(returnType, name, parameterList);
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1474,20 +1474,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
 
         // add new methods
         for (UnsolvedMethod method : missedClass.getMethods()) {
-          // this boolean checks if the required method is already inside the related synthetic
-          // class. In that case, no need to add another one.
-          boolean alreadyHad = false;
-          for (UnsolvedMethod classMethod : e.getMethods()) {
-            if (classMethod.getReturnType().equals(method.getReturnType())) {
-              if (classMethod.getName().equals(method.getName())) {
-                alreadyHad = true;
-                break;
-              }
-            }
-          }
-          if (!alreadyHad) {
-            e.addMethod(method);
-          }
+          // No need to check for containment, since the methods are stored
+          // as a set (which does not permit duplicates).
+          e.addMethod(method);
         }
 
         // add new fields

--- a/src/test/java/org/checkerframework/specimin/OverloadsTest.java
+++ b/src/test/java/org/checkerframework/specimin/OverloadsTest.java
@@ -1,0 +1,15 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test checks that Specimin respects Java's rules for overloading methods. */
+public class OverloadsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "overloads",
+        new String[] {"com/example/OverloadExamples.java"},
+        new String[] {"com.example.OverloadExamples#test(MultipleMethods)"});
+  }
+}

--- a/src/test/resources/overloads/expected/com/example/OverloadExamples.java
+++ b/src/test/resources/overloads/expected/com/example/OverloadExamples.java
@@ -1,0 +1,17 @@
+package com.example;
+
+import org.example.MultipleMethods;
+
+public class OverloadExamples {
+    void test(MultipleMethods m) {
+        m.example();
+        m.example("foo");
+        m.example(5);
+        m.example(null);
+        m.example("foo", 5);
+        m.example(5, "foo");
+        m.example(5, 5);
+        m.example("foo", "foo");
+        m.example(null, null);
+    }
+}

--- a/src/test/resources/overloads/expected/org/example/ExampleReturnType.java
+++ b/src/test/resources/overloads/expected/org/example/ExampleReturnType.java
@@ -1,0 +1,3 @@
+package org.example;
+public class ExampleReturnType {
+}

--- a/src/test/resources/overloads/expected/org/example/MultipleMethods.java
+++ b/src/test/resources/overloads/expected/org/example/MultipleMethods.java
@@ -5,11 +5,19 @@ public class MultipleMethods {
         throw new Error();
     }
 
+    public ExampleReturnType example(java.lang.String parameter0) {
+        throw new Error();
+    }
+
     public ExampleReturnType example(int parameter0) {
         throw new Error();
     }
 
-    public ExampleReturnType example(String parameter0) {
+    public ExampleReturnType example(java.lang.String parameter0, int parameter1) {
+        throw new Error();
+    }
+
+    public ExampleReturnType example(int parameter0, java.lang.String parameter1) {
         throw new Error();
     }
 
@@ -17,15 +25,7 @@ public class MultipleMethods {
         throw new Error();
     }
 
-    public ExampleReturnType example(String parameter0, int parameter1) {
-        throw new Error();
-    }
-
-    public ExampleReturnType example(int parameter0, String parameter1) {
-        throw new Error();
-    }
-
-    public ExampleReturnType example(String parameter0, String parameter1) {
+    public ExampleReturnType example(java.lang.String parameter0, java.lang.String parameter1) {
         throw new Error();
     }
 }

--- a/src/test/resources/overloads/expected/org/example/MultipleMethods.java
+++ b/src/test/resources/overloads/expected/org/example/MultipleMethods.java
@@ -1,0 +1,31 @@
+package org.example;
+
+public class MultipleMethods {
+    public ExampleReturnType example() {
+        throw new Error();
+    }
+
+    public ExampleReturnType example(int parameter0) {
+        throw new Error();
+    }
+
+    public ExampleReturnType example(String parameter0) {
+        throw new Error();
+    }
+
+    public ExampleReturnType example(int parameter0, int parameter1) {
+        throw new Error();
+    }
+
+    public ExampleReturnType example(String parameter0, int parameter1) {
+        throw new Error();
+    }
+
+    public ExampleReturnType example(int parameter0, String parameter1) {
+        throw new Error();
+    }
+
+    public ExampleReturnType example(String parameter0, String parameter1) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/overloads/input/com/example/OverloadExamples.java
+++ b/src/test/resources/overloads/input/com/example/OverloadExamples.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import org.example.MultipleMethods;
+
+public class OverloadExamples {
+    void test(MultipleMethods m) {
+        // I expect to create 1 method with no arguments,
+        // two methods with one argument, and four methods
+        // with two arguments - that is, the powerset of String
+        // and int. TODO: more examples for return types.
+        m.example();
+        m.example("foo");
+        m.example(5);
+        m.example(null);
+        m.example("foo", 5);
+        m.example(5, "foo");
+        m.example(5, 5);
+        m.example("foo", "foo");
+        m.example(null, null);
+    }
+}


### PR DESCRIPTION
This solves one infinite loop that #87 triggers, but not all of them. The new test in this PR causes an infinite loop on `main`.