### PR TITLE
Codes to keep original class files

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1467,8 +1467,10 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    * @param missedClass the class to be updated
    */
   public void updateMissingClass(UnsolvedClass missedClass) {
+    // If an original class from the input codebase is used with unsolved type parameters, it may be
+    // misunderstood as an unresolved class.
     if (classfileIsInOriginalCodebase(
-            missedClass.getPackageName() + "." + missedClass.getClassName())) {
+        missedClass.getPackageName() + "." + missedClass.getClassName())) {
       return;
     }
     Iterator<UnsolvedClass> iterator = missingClass.iterator();
@@ -1511,7 +1513,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     }
     relativeClassPath = relativeClassPath + ".java";
     return this.setOfExistingFiles.contains(
-            Paths.get(this.rootDirectory + "/" + relativeClassPath).toAbsolutePath());
+        Paths.get(this.rootDirectory + "/" + relativeClassPath).toAbsolutePath());
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1467,6 +1467,10 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    * @param missedClass the class to be updated
    */
   public void updateMissingClass(UnsolvedClass missedClass) {
+    if (classfileIsInOriginalCodebase(
+            missedClass.getPackageName() + "." + missedClass.getClassName())) {
+      return;
+    }
     Iterator<UnsolvedClass> iterator = missingClass.iterator();
     while (iterator.hasNext()) {
       UnsolvedClass e = iterator.next();
@@ -1490,6 +1494,24 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       }
     }
     missingClass.add(missedClass);
+  }
+
+  /**
+   * Given the qualified name of a class, this method determines if the corresponding class file
+   * exists in the original input codebase.
+   *
+   * @param qualifiedName the qualified name of a class.
+   * @return true if the corresponding class file is origi nally in the input codebase.
+   */
+  public boolean classfileIsInOriginalCodebase(String qualifiedName) {
+    String relativeClassPath = qualifiedName.replace(".", "/");
+    int indexOfTypeVariables = relativeClassPath.indexOf("<");
+    if (indexOfTypeVariables != -1) {
+      relativeClassPath = relativeClassPath.substring(0, indexOfTypeVariables);
+    }
+    relativeClassPath = relativeClassPath + ".java";
+    return this.setOfExistingFiles.contains(
+            Paths.get(this.rootDirectory + "/" + relativeClassPath).toAbsolutePath());
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1503,7 +1503,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    * exists in the original input codebase.
    *
    * @param qualifiedName the qualified name of a class.
-   * @return true if the corresponding class file is origi nally in the input codebase.
+   * @return true if the corresponding class file is originally in the input codebase.
    */
   public boolean classfileIsInOriginalCodebase(String qualifiedName) {
     String relativeClassPath = qualifiedName.replace(".", "/");

--- a/src/test/java/org/checkerframework/specimin/GenericTypeMethodTest.java
+++ b/src/test/java/org/checkerframework/specimin/GenericTypeMethodTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that a simple Java file with no dependencies and a single target method with one
+ * method that it depends on results in that depended-on method being replaced by an empty body.
+ */
+public class OneFileSimpleTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "onefilesimple",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/GenericTypeMethodTest.java
+++ b/src/test/java/org/checkerframework/specimin/GenericTypeMethodTest.java
@@ -4,15 +4,15 @@ import java.io.IOException;
 import org.junit.Test;
 
 /**
- * This test checks that a simple Java file with no dependencies and a single target method with one
- * method that it depends on results in that depended-on method being replaced by an empty body.
+ * This test makes sure that Specimin will not modify existing class file in the input codebase when
+ * dealing with a method with generic return type.
  */
-public class OneFileSimpleTest {
+public class GenericTypeMethodTest {
   @Test
   public void runTest() throws IOException {
     SpeciminTestExecutor.runTestWithoutJarPaths(
-        "onefilesimple",
-        new String[] {"com/example/Simple.java"},
-        new String[] {"com.example.Simple#bar()"});
+        "generictypemethod",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#bar()"});
   }
 }

--- a/src/test/resources/generictypemethod/expected/com/example/Baz.java
+++ b/src/test/resources/generictypemethod/expected/com/example/Baz.java
@@ -1,0 +1,8 @@
+package com.example;
+
+public class Baz<T> {
+
+    public T baz() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/generictypemethod/expected/com/example/Foo.java
+++ b/src/test/resources/generictypemethod/expected/com/example/Foo.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.testing.UnsolvedType;
+
+class Foo {
+
+    protected Baz<UnsolvedType> field;
+
+    void bar() {
+        field.baz();
+    }
+}

--- a/src/test/resources/generictypemethod/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/generictypemethod/expected/org/testing/UnsolvedType.java
@@ -1,0 +1,4 @@
+package org.testing;
+
+public class UnsolvedType {
+}

--- a/src/test/resources/generictypemethod/input/com/example/Baz.java
+++ b/src/test/resources/generictypemethod/input/com/example/Baz.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Baz <T> {
+    public T baz() {
+        throw new Exception();
+    }
+}

--- a/src/test/resources/generictypemethod/input/com/example/Foo.java
+++ b/src/test/resources/generictypemethod/input/com/example/Foo.java
@@ -1,0 +1,9 @@
+package com.example;
+import org.testing.UnsolvedType;
+
+class Foo {
+    protected Baz<UnsolvedType> field;
+    void bar() {
+        field.baz();
+    }
+}


### PR DESCRIPTION
Professor,

This is the PR to enforce that original class files are kept untouched.

Given an original class in the input codebase with generic types, such as `Resolved<T, V>`, if that type is used with unsolved type parameters, such as `Resolved<Unsolved, Unsolved>`, Specimin can confuse `Resolved` to be an unsolved type that needs synthetic classes created. It is rather difficult to solve this confusion of Specimin, since JavaParser does not have any straightforward mechanism to separate a type from its type parameters. It's easier to prevent Specimin to make any changes to original class files. And when the unsolved type parameters are solved by the visit method for `ClassOrInterfaceType`, the problem will disappear automatically.