### PR TITLE
Make sure root ends with slash

### DIFF
--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -89,6 +89,12 @@ public class SpeciminRunner {
       String outputDirectory)
       throws IOException {
 
+    // To facilitate string manipulation in subsequent methods, ensure that 'root' ends with a
+    // trailing slash.
+    if (!root.endsWith("/")) {
+      root = root + "/";
+    }
+
     // Set up the parser's symbol solver, so that we can resolve definitions.
     CombinedTypeSolver typeSolver =
         new CombinedTypeSolver(


### PR DESCRIPTION
This PR addresses a minor enhancement by automatically appending an ending slash to the root directory if one is not present. 
