### PR TITLE
Failing test case where a used method is not created properly by Specimin

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1896,7 +1896,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         relatedClass.updateFieldByType(incorrectType, typeToCorrect.get(incorrectType));
         this.deleteOldSyntheticClass(relatedClass);
         this.createMissingClass(relatedClass);
-        return;
+        continue;
       }
       UnsolvedClass relatedClass = syntheticMethodReturnTypeAndClass.get(incorrectType);
       if (relatedClass != null) {

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1893,22 +1893,22 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       // update incorrecType if it is the type of a field in a synthetic class
       if (syntheticTypeAndClass.containsKey(incorrectType)) {
         UnsolvedClass relatedClass = syntheticTypeAndClass.get(incorrectType);
-        relatedClass.updateFieldByType(incorrectType, typeToCorrect.get(incorrectType));
-        this.deleteOldSyntheticClass(relatedClass);
-        this.createMissingClass(relatedClass);
+        updateTypeForSyntheticClasses(
+            relatedClass.getClassName(),
+            relatedClass.getPackageName(),
+            true,
+            incorrectType,
+            typeToCorrect.get(incorrectType));
         continue;
       }
       UnsolvedClass relatedClass = syntheticMethodReturnTypeAndClass.get(incorrectType);
       if (relatedClass != null) {
-        for (UnsolvedClass syntheticClass : missingClass) {
-          if (syntheticClass.equals(relatedClass)) {
-            syntheticClass.updateMethodByReturnType(
-                incorrectType, typeToCorrect.get(incorrectType));
-            this.deleteOldSyntheticClass(syntheticClass);
-            this.createMissingClass(syntheticClass);
-          }
-        }
-        relatedClass.updateMethodByReturnType(incorrectType, typeToCorrect.get(incorrectType));
+        updateTypeForSyntheticClasses(
+            relatedClass.getClassName(),
+            relatedClass.getPackageName(),
+            false,
+            incorrectType,
+            typeToCorrect.get(incorrectType));
       }
       // if the above condition is not met, then this incorrectType is a synthetic type for the
       // fields of the parent class rather than the return type of some methods
@@ -1926,6 +1926,42 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         }
       }
     }
+  }
+
+  /**
+   * Updates the types for fields or methods in a synthetic class.
+   *
+   * @param className        The name of the synthetic class.
+   * @param packageName      The package of the synthetic class.
+   * @param updateAField     True if updating the type of a field, false to update the type of a method.
+   * @param incorrectTypeName The name of the current incorrect type.
+   * @param correctTypeName   The name of the desired correct type.
+   */
+  public void updateTypeForSyntheticClasses(
+      String className,
+      String packageName,
+      boolean updateAField,
+      String incorrectTypeName,
+      String correctTypeName) {
+    UnsolvedClass classToSearch = new UnsolvedClass(className, packageName);
+    Iterator<UnsolvedClass> iterator = missingClass.iterator();
+    while (iterator.hasNext()) {
+      UnsolvedClass missedClass = iterator.next();
+      // Class comparison is based on class name and package name only.
+      if (missedClass.equals(classToSearch)) {
+        iterator.remove(); // Remove the outdated version of this synthetic class from the list
+        if (updateAField) {
+          missedClass.updateFieldByType(incorrectTypeName, correctTypeName);
+        } else {
+          missedClass.updateMethodByReturnType(incorrectTypeName, correctTypeName);
+        }
+        missingClass.add(missedClass); // Add the modified missedClass back to the list
+        this.deleteOldSyntheticClass(missedClass);
+        this.createMissingClass(missedClass);
+        return;
+      }
+    }
+    throw new RuntimeException("Could not find the corresponding missing class!");
   }
 
   /**

--- a/src/test/java/org/checkerframework/specimin/BooleanReturnTest.java
+++ b/src/test/java/org/checkerframework/specimin/BooleanReturnTest.java
@@ -1,0 +1,22 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that if Specimin can correctly deduce that the return type of an unsolved method
+ * that is used as an if or loop guard must be boolean.
+ */
+public class BooleanReturnTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "booleanreturn",
+        new String[] {"com/example/Simple.java"},
+        new String[] {
+          "com.example.Simple#test()",
+          "com.example.Simple#testFoo(Foo)",
+          "com.example.Simple#testFoo2(Foo)"
+        });
+  }
+}

--- a/src/test/resources/booleanreturn/expected/com/example/Simple.java
+++ b/src/test/resources/booleanreturn/expected/com/example/Simple.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import org.example.ElementUtils;
+import org.example.Foo;
+
+class Simple {
+    void test() {
+        if (ElementUtils.isEffectivelyFinal()) {
+        }
+    }
+
+    void testFoo(Foo f) {
+        if (f.isGood()) {
+        }
+    }
+
+    void testFoo2(Foo f) {
+        if (f.good) {
+        }
+    }
+}

--- a/src/test/resources/booleanreturn/expected/org/example/ElementUtils.java
+++ b/src/test/resources/booleanreturn/expected/org/example/ElementUtils.java
@@ -1,0 +1,7 @@
+package org.example;
+
+public class ElementUtils {
+    public static boolean isEffectivelyFinal() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/booleanreturn/expected/org/example/Foo.java
+++ b/src/test/resources/booleanreturn/expected/org/example/Foo.java
@@ -5,6 +5,6 @@ public class Foo {
     public boolean good;
 
     public boolean isGood() {
-        return new Error();
+        throw new Error();
     }
 }

--- a/src/test/resources/booleanreturn/expected/org/example/Foo.java
+++ b/src/test/resources/booleanreturn/expected/org/example/Foo.java
@@ -1,0 +1,10 @@
+package org.example;
+
+public class Foo {
+
+    public boolean good;
+
+    public boolean isGood() {
+        return new Error();
+    }
+}

--- a/src/test/resources/booleanreturn/input/com/example/Simple.java
+++ b/src/test/resources/booleanreturn/input/com/example/Simple.java
@@ -1,0 +1,27 @@
+package com.example;
+
+import org.example.ElementUtils;
+import org.example.Foo;
+
+class Simple {
+    // First target method: static call
+    void test() {
+        if (ElementUtils.isEffectivelyFinal()) {
+            // do something
+        }
+    }
+
+    // Second target method: instance method
+    void testFoo(Foo f) {
+        if (f.isGood()) {
+            // do something
+        }
+    }
+
+    // Second target method: unsolved field
+    void testFoo2(Foo f) {
+        if (f.good) {
+            // do something
+        }
+    }
+}


### PR DESCRIPTION
In particular, Specimin does not create the `org.example.Foo#isGood()` method (I'm not sure why).

The goal of this test was to make sure that Specimin correctly makes methods/fields that need to return booleans (because they are used in if guards) actually have boolean returns (instead of a synthetic return class). That part seems to be working (good!), but I'm not sure why the `isGood()` method isn't created. @LoiNguyenCS can you take a look at this and either 1) fix it, or 2) let me know why my test case isn't correct? Thanks.