### PR TITLE
Speed up tests by running them in parallel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,11 @@ javadoc {
     }
 }
 
+tasks.withType(Test).configureEach {
+    // Creates half as many forks as there are CPU cores.
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+}
+
 test {
     testLogging {
         showStandardStreams = true


### PR DESCRIPTION
Speeds up `./gradlew test` from ~50 seconds to ~15 seconds on my laptop. (Still too slow, but much better!)