### PR TITLE
Another failing test case

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,11 @@ javadoc {
     }
 }
 
+tasks.withType(Test).configureEach {
+    // Creates half as many forks as there are CPU cores.
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+}
+
 test {
     testLogging {
         showStandardStreams = true

--- a/src/test/java/org/checkerframework/specimin/ExtendsSourceButNotTargetTest.java
+++ b/src/test/java/org/checkerframework/specimin/ExtendsSourceButNotTargetTest.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that Specimin can correctly resolve a test case where there is a three-class
+ * chain of extends clauses from the target file/class to another class that is provided as a source
+ * file (but which is not a target). In other words, this test's goal is to make sure that Specimin
+ * is handling files that are source-available but not targets correctly.
+ */
+public class ExtendsSourceButNotTargetTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "extendssourcebutnottarget",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/extendssourcebutnottarget/expected/com/example/B.java
+++ b/src/test/resources/extendssourcebutnottarget/expected/com/example/B.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public class B extends C {
+
+}

--- a/src/test/resources/extendssourcebutnottarget/expected/com/example/C.java
+++ b/src/test/resources/extendssourcebutnottarget/expected/com/example/C.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class C {
+    public void foo() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/extendssourcebutnottarget/expected/com/example/Simple.java
+++ b/src/test/resources/extendssourcebutnottarget/expected/com/example/Simple.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Simple extends B {
+    void bar() {
+        foo();
+    }
+}

--- a/src/test/resources/extendssourcebutnottarget/input/com/example/B.java
+++ b/src/test/resources/extendssourcebutnottarget/input/com/example/B.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public class B extends C {
+
+}

--- a/src/test/resources/extendssourcebutnottarget/input/com/example/C.java
+++ b/src/test/resources/extendssourcebutnottarget/input/com/example/C.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class C {
+    public void foo() {
+
+    }
+}

--- a/src/test/resources/extendssourcebutnottarget/input/com/example/Simple.java
+++ b/src/test/resources/extendssourcebutnottarget/input/com/example/Simple.java
@@ -1,0 +1,9 @@
+package com.example;
+
+public class Simple extends B {
+    // Target method.
+    void bar() {
+        // foo() is defined in class C
+        foo();
+    }
+}


### PR DESCRIPTION
@LoiNguyenCS this test is based on our conversation yesterday, where you hypothesized that a test case like this one would trigger an infinite loop. It doesn't do that, but the output is not compilable: no `B.java` is produced, but `Simple` still extends `B`.