### PR TITLE
remove isInsideInterface

### DIFF
--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -59,9 +59,6 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
    */
   private Set<String> classesUsedByTargetMethods;
 
-  /** This is to check whether the current compilation unit is a class or an interface. */
-  private boolean isInsideAnInterface = false;
-
   /**
    * This boolean tracks whether the element currently being visited is inside a target method. It
    * is set by {@link #visit(MethodDeclaration, Void)}.
@@ -109,9 +106,7 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
       decl.remove();
       return decl;
     }
-    if (decl.isInterface()) {
-      this.isInsideAnInterface = true;
-    } else {
+    if (!decl.isInterface()) {
       NodeList<ClassOrInterfaceType> implementedInterfaces = decl.getImplementedTypes();
       Iterator<ClassOrInterfaceType> iterator = implementedInterfaces.iterator();
       while (iterator.hasNext()) {
@@ -155,7 +150,8 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
       insideTargetMethod = false;
       return result;
     } else if (membersToEmpty.contains(resolved.getQualifiedSignature())) {
-      if (!isInsideAnInterface) {
+      // do nothing if methodDecl is just a method signature.
+      if (methodDecl.getBody().isPresent()) {
         methodDecl.setBody(StaticJavaParser.parseBlock("{ throw new Error(); }"));
       }
       return methodDecl;

--- a/src/test/resources/MethodInEnum/expected/com/example/Foo.java
+++ b/src/test/resources/MethodInEnum/expected/com/example/Foo.java
@@ -18,9 +18,7 @@ class Foo {
         }
         ;
 
-        public abstract void testing() {
-            throw new Error();
-        }
+        public abstract void testing();
     }
 
     private void bar() {

--- a/src/test/resources/implicitinterfaceaccessmethodoverload/expected/com/example/Simple.java
+++ b/src/test/resources/implicitinterfaceaccessmethodoverload/expected/com/example/Simple.java
@@ -13,6 +13,6 @@ abstract class Simple implements B {
     }
 
     int foo(int x) {
-        return 0;
+        throw new Error();
     }
 }


### PR DESCRIPTION
Professor,

Turns out that the field `isInsideAnInterface` was buggy; once set to `true`, it remained permanently in that state. So I have removed that field. I have also fixed a test file we had in the past, where a used method should have an empty body.