### PR TITLE
Handle fields with multiple variable declarators

### DIFF
--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -194,6 +194,7 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
     if (insideTargetMethod) {
       return super.visit(fieldDecl, p);
     }
+
     boolean isFinal = fieldDecl.isFinal();
     // Fields must have parents, because they must be contained in a class.
     // TODO: is this the best way to do this here? So many unguarded .get() calls makes me nervous.

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -367,14 +367,6 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
       if (methodReturnType instanceof ResolvedReferenceType) {
         updateUsedClassBasedOnType(methodReturnType);
       }
-      if (call.getScope().isPresent()) {
-        Expression scope = call.getScope().get();
-        // if the scope of a method call is a field, the type of that scope will be NameExpr.
-        if (scope instanceof NameExpr) {
-          NameExpr expression = call.getScope().get().asNameExpr();
-          updateUsedElementWithPotentialFieldNameExpr(expression);
-        }
-      }
     }
     return super.visit(call, p);
   }

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -452,9 +452,7 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   public Visitable visit(NameExpr expr, Void p) {
     if (insideTargetMethod) {
       Optional<Node> parentNode = expr.getParentNode();
-      if (parentNode.isEmpty()
-          || !(parentNode.get() instanceof MethodCallExpr
-              || parentNode.get() instanceof FieldAccessExpr)) {
+      if (parentNode.isEmpty() || !(parentNode.get() instanceof FieldAccessExpr)) {
         updateUsedElementWithPotentialFieldNameExpr(expr);
       }
     }

--- a/src/test/java/org/checkerframework/specimin/MultipleVariableDeclaratorsTest.java
+++ b/src/test/java/org/checkerframework/specimin/MultipleVariableDeclaratorsTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that a simple Java file with a field declaration with more than one variable
+ * declarator does not cause Specimin to crash.
+ */
+public class MultipleVariableDeclaratorsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "multiplevariabledeclarators",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/multiplevariabledeclarators/expected/com/example/Simple.java
+++ b/src/test/resources/multiplevariabledeclarators/expected/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+class Simple {
+
+    Object obj1, obj2;
+
+    void bar() {
+        obj1 = baz(obj2);
+    }
+
+    Object baz(Object obj) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/multiplevariabledeclarators/expected/com/example/Simple.java
+++ b/src/test/resources/multiplevariabledeclarators/expected/com/example/Simple.java
@@ -4,8 +4,15 @@ class Simple {
 
     Object obj1, obj2;
 
+    Object obj3;
+
+    Object obj6;
+
     void bar() {
-        obj1 = baz(obj2);
+        baz(obj1);
+        baz(obj2);
+        baz(obj3);
+        baz(obj6);
     }
 
     Object baz(Object obj) {

--- a/src/test/resources/multiplevariabledeclarators/input/com/example/Simple.java
+++ b/src/test/resources/multiplevariabledeclarators/input/com/example/Simple.java
@@ -1,0 +1,15 @@
+package com.example;
+
+class Simple {
+
+    Object obj1, obj2;
+
+    // Target method.
+    void bar() {
+        obj1 = baz(obj2);
+    }
+
+    Object baz(Object obj) {
+        return obj.toString();
+    }
+}

--- a/src/test/resources/multiplevariabledeclarators/input/com/example/Simple.java
+++ b/src/test/resources/multiplevariabledeclarators/input/com/example/Simple.java
@@ -2,11 +2,24 @@ package com.example;
 
 class Simple {
 
+    // Both used, both should be preserved.
     Object obj1, obj2;
+
+    // Only first used.
+    Object obj3, obj4;
+
+    // Only second used.
+    Object obj5, obj6;
+
+    // Neither used.
+    Object obj7, obj8;
 
     // Target method.
     void bar() {
-        obj1 = baz(obj2);
+        baz(obj1);
+        baz(obj2);
+        baz(obj3);
+        baz(obj6);
     }
 
     Object baz(Object obj) {


### PR DESCRIPTION
Note that for debugging purposes, this PR already includes the change in #131. Merge #131 before reviewing this PR.

@LoiNguyenCS is there a better way to get the full class name in `PrunerVisitor` that you're aware of? I'm not particularly confident in how I did it, but it seems to work on the test cases.

The change in `TargetMethodFinderVisitor` is necessary because without it, code like:
```
baz(obj1);
```
where `obj1` is a field fail to register `obj1` as a used member. Removing that logic didn't cause a test to fail, so I'm not sure why it was there. @LoiNguyenCS do you know why it was originally present? There's no documentation that I can see, and `git blame` doesn't help (it points to https://github.com/kelloggm/specimin/commit/fac443546259ad285f446a2ae39377ac3d26b4d5, which doesn't have any documentation associated with it that I can find).