### PR TITLE
Resolve crash when encountering a field inside an enum

### DIFF
--- a/src/main/java/org/checkerframework/specimin/FieldDeclarationsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/FieldDeclarationsVisitor.java
@@ -1,6 +1,8 @@
 package org.checkerframework.specimin;
 
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
@@ -31,12 +33,21 @@ public class FieldDeclarationsVisitor extends VoidVisitorAdapter<Void> {
 
   @Override
   public void visit(FieldDeclaration decl, Void p) {
-    if (decl.getParentNode().get() instanceof ObjectCreationExpr) {
+    Node parent = decl.getParentNode().get();
+
+    if (parent instanceof ObjectCreationExpr) {
       return;
     }
-    ClassOrInterfaceDeclaration classNode =
-        (ClassOrInterfaceDeclaration) decl.getParentNode().get();
-    SimpleName classNodeSimpleName = classNode.getName();
+    SimpleName classNodeSimpleName;
+    if (parent instanceof ClassOrInterfaceDeclaration) {
+      ClassOrInterfaceDeclaration classNode = (ClassOrInterfaceDeclaration) parent;
+      classNodeSimpleName = classNode.getName();
+    } else if (parent instanceof EnumDeclaration) {
+      EnumDeclaration enumNode = (EnumDeclaration) parent;
+      classNodeSimpleName = enumNode.getName();
+    } else {
+      throw new RuntimeException("unexpected node type: " + parent.getClass());
+    }
     String className = classNodeSimpleName.asString();
     for (VariableDeclarator var : decl.getVariables()) {
       fieldNameToClassNameMap.put(var.getNameAsString(), className);

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -25,10 +25,10 @@ import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
-import com.github.javaparser.resolution.declarations.ResolvedConstructorDeclaration;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Set;
 import org.checkerframework.checker.signature.qual.FullyQualifiedName;
 
@@ -169,20 +169,25 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
 
   @Override
   public Visitable visit(ConstructorDeclaration constructorDecl, Void p) {
+    String qualifiedSignature;
     try {
       // resolved() will only check if the return type is solvable
       // getQualifiedSignature() will also check if the parameters are solvable
-      constructorDecl.resolve().getQualifiedSignature();
+      qualifiedSignature = constructorDecl.resolve().getQualifiedSignature();
     } catch (UnsolvedSymbolException e) {
       // The current class is employed by the target methods, although not all of its members are
       // utilized. It's not surprising for unused members to remain unresolved.
       constructorDecl.remove();
       return constructorDecl;
     }
-    ResolvedConstructorDeclaration resolved = constructorDecl.resolve();
-    if (methodsToLeaveUnchanged.contains(resolved.getQualifiedSignature())) {
+
+    // TODO: we should be cleverer about whether to preserve the constructors of
+    // enums, but right now we don't remove any enum constants in related classes, so
+    // we need to preserve all constructors to retain compilability.
+
+    if (methodsToLeaveUnchanged.contains(qualifiedSignature)) {
       return super.visit(constructorDecl, p);
-    } else if (membersToEmpty.contains(resolved.getQualifiedSignature())) {
+    } else if (membersToEmpty.contains(qualifiedSignature) || isInEnum(constructorDecl)) {
       constructorDecl.setBody(StaticJavaParser.parseBlock("{ throw new Error(); }"));
       return constructorDecl;
     } else {
@@ -324,5 +329,23 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
     } else {
       throw new RuntimeException("unexpected kind of node: " + parent.getClass());
     }
+  }
+
+  /**
+   * Returns true iff the innermost enclosing class/interface is an enum.
+   *
+   * @param node any node
+   * @return true if the enclosing class is an enum, false otherwise
+   */
+  public static boolean isInEnum(Node node) {
+    Optional<Node> parent = node.getParentNode();
+    while (parent.isPresent()) {
+      Node actualParent = parent.get();
+      if (actualParent instanceof EnumDeclaration) {
+        return true;
+      }
+      parent = actualParent.getParentNode();
+    }
+    return false;
   }
 }

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.InitializerDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -310,13 +311,18 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
    * @param node a node contained in a class or interface
    * @return the fully-qualified name of the inner-most containing class or interface
    */
+  @SuppressWarnings("signature") // result is a fully-qualified name or else this throws
   public static @FullyQualifiedName String getEnclosingClassName(Node node) {
     Node parent = node.getParentNode().orElseThrow();
-    while (!(parent instanceof ClassOrInterfaceDeclaration)) {
+    while (!(parent instanceof ClassOrInterfaceDeclaration || parent instanceof EnumDeclaration)) {
       parent = parent.getParentNode().orElseThrow();
     }
-    @SuppressWarnings("signature") // result is a fully-qualified name or else this throws
-    @FullyQualifiedName String result = ((ClassOrInterfaceDeclaration) parent).getFullyQualifiedName().orElseThrow();
-    return result;
+    if (parent instanceof ClassOrInterfaceDeclaration) {
+      return ((ClassOrInterfaceDeclaration) parent).getFullyQualifiedName().orElseThrow();
+    } else if (parent instanceof EnumDeclaration) {
+      return ((EnumDeclaration) parent).getFullyQualifiedName().orElseThrow();
+    } else {
+      throw new RuntimeException("unexpected kind of node: " + parent.getClass());
+    }
   }
 }

--- a/src/test/java/org/checkerframework/specimin/FieldInEnumTest.java
+++ b/src/test/java/org/checkerframework/specimin/FieldInEnumTest.java
@@ -1,0 +1,15 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test checks if Specimin can handle a field inside an enum constant declaration. */
+public class FieldInEnumTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "fieldinenum",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#bar()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/UnrelatedEnumTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnrelatedEnumTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that the presence of an enum in an unrelated target class (Foo) does not cause
+ * that class to be preserved.
+ */
+public class UnrelatedEnumTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unrelatedenum",
+        new String[] {"com/example/Simple.java", "com/example/Foo.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/fieldinenum/expected/com/example/Foo.java
+++ b/src/test/resources/fieldinenum/expected/com/example/Foo.java
@@ -4,7 +4,11 @@ class Foo {
 
     private enum Status {
 
-        ON(1), OFF(0)
+        ON(1), OFF(0);
+
+        int bitRep;
+
+        Status(int x) { }
     }
 
     private void bar() {

--- a/src/test/resources/fieldinenum/expected/com/example/Foo.java
+++ b/src/test/resources/fieldinenum/expected/com/example/Foo.java
@@ -4,11 +4,14 @@ class Foo {
 
     private enum Status {
 
-        ON(1), OFF(0);
+        ON(1),
+        OFF(0);
 
         int bitRep;
 
-        Status(int x) { }
+        Status(int x) {
+            throw new Error();
+        }
     }
 
     private void bar() {

--- a/src/test/resources/fieldinenum/expected/com/example/Foo.java
+++ b/src/test/resources/fieldinenum/expected/com/example/Foo.java
@@ -1,0 +1,16 @@
+package com.example;
+
+class Foo {
+
+    private enum STATUS{
+        ON {
+            int x, y;
+        },
+        OFF {
+        };
+    }
+
+    private void bar() {
+        STATUS.ON.x;
+    }
+}

--- a/src/test/resources/fieldinenum/expected/com/example/Foo.java
+++ b/src/test/resources/fieldinenum/expected/com/example/Foo.java
@@ -2,15 +2,12 @@ package com.example;
 
 class Foo {
 
-    private enum STATUS{
-        ON {
-            int x, y;
-        },
-        OFF {
-        };
+    private enum Status {
+
+        ON(1), OFF(0)
     }
 
     private void bar() {
-        STATUS.ON.x;
+        int y = Status.ON.bitRep;
     }
 }

--- a/src/test/resources/fieldinenum/input/com/example/Foo.java
+++ b/src/test/resources/fieldinenum/input/com/example/Foo.java
@@ -3,6 +3,7 @@ package com.example;
 class Foo {
 
     private enum Status{
+        // OFF is currently preserved, which is undesirable.
         ON(1), OFF(0);
 
         int bitRep;

--- a/src/test/resources/fieldinenum/input/com/example/Foo.java
+++ b/src/test/resources/fieldinenum/input/com/example/Foo.java
@@ -1,0 +1,16 @@
+package com.example;
+
+class Foo {
+
+    private enum STATUS{
+        ON {
+            int x, y;
+        },
+        OFF {
+        };
+    }
+
+    private void bar() {
+        STATUS.ON.x;
+    }
+}

--- a/src/test/resources/fieldinenum/input/com/example/Foo.java
+++ b/src/test/resources/fieldinenum/input/com/example/Foo.java
@@ -2,15 +2,17 @@ package com.example;
 
 class Foo {
 
-    private enum STATUS{
-        ON {
-            int x, y;
-        },
-        OFF {
-        };
+    private enum Status{
+        ON(1), OFF(0);
+
+        int bitRep;
+
+        Status(int x) {
+            bitRep = x;
+        }
     }
 
     private void bar() {
-        STATUS.ON.x;
+        int y = Status.ON.bitRep;
     }
 }

--- a/src/test/resources/unrelatedenum/expected/com/example/Simple.java
+++ b/src/test/resources/unrelatedenum/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+class Simple {
+
+    void bar() {
+        Object obj = new Object();
+        obj = baz(obj);
+    }
+
+    Object baz(Object obj) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/unrelatedenum/input/com/example/Foo.java
+++ b/src/test/resources/unrelatedenum/input/com/example/Foo.java
@@ -1,0 +1,19 @@
+package com.example;
+
+class Foo {
+
+    private enum Status{
+        // OFF is currently preserved, which is undesirable.
+        ON(1), OFF(0);
+
+        int bitRep;
+
+        Status(int x) {
+            bitRep = x;
+        }
+    }
+
+    private void bar() {
+        int y = Status.ON.bitRep;
+    }
+}

--- a/src/test/resources/unrelatedenum/input/com/example/Simple.java
+++ b/src/test/resources/unrelatedenum/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+class Simple {
+    // Target method.
+    void bar() {
+        Object obj = new Object();
+        obj = baz(obj);
+    }
+
+    Object baz(Object obj) {
+        return obj.toString();
+    }
+}

--- a/typecheck_test_outputs.sh
+++ b/typecheck_test_outputs.sh
@@ -15,7 +15,7 @@ for testcase in * ; do
     cd "${testcase}/expected/" || exit 1
     # javac relies on word splitting
     # shellcheck disable=SC2046
-    javac -classpath "../../shared/checker-qual-3.42.0.jar" $(find . -name "*.java") \
+    javac -proc:only -nowarn -classpath "../../shared/checker-qual-3.42.0.jar" $(find . -name "*.java") \
       || { echo "Running javac on ${testcase}/expected issues one or more errors, which are printed above."; returnval=2; }
     cd ../.. || exit 1
 done

--- a/typecheck_test_outputs.sh
+++ b/typecheck_test_outputs.sh
@@ -15,7 +15,7 @@ for testcase in * ; do
     cd "${testcase}/expected/" || exit 1
     # javac relies on word splitting
     # shellcheck disable=SC2046
-    javac -proc:only -nowarn -classpath "../../shared/checker-qual-3.42.0.jar" $(find . -name "*.java") \
+    javac -classpath "../../shared/checker-qual-3.42.0.jar" $(find . -name "*.java") \
       || { echo "Running javac on ${testcase}/expected issues one or more errors, which are printed above."; returnval=2; }
     cd ../.. || exit 1
 done


### PR DESCRIPTION
Fixes a crash in CF-6388, although I haven't yet checked if that target has other problems. The proximate cause of the crash was `FieldDeclarationsVisitor`, with the following stack trace:
```
Exception in thread "main" java.lang.ClassCastException: class com.github.javaparser.ast.body.EnumDeclaration cannot be cast to class com.github.javaparser.ast.body.ClassOrInterfaceDeclaration (com.github.javaparser.ast.body.EnumDeclaration and com.github.javaparser.ast.body.ClassOrInterfaceDeclaration are in unnamed module of loader 'app')
	at org.checkerframework.specimin.FieldDeclarationsVisitor.visit(FieldDeclarationsVisitor.java:38)
	at org.checkerframework.specimin.FieldDeclarationsVisitor.visit(FieldDeclarationsVisitor.java:20)
	at com.github.javaparser.ast.body.FieldDeclaration.accept(FieldDeclaration.java:116)
...
```

However, fixing that led me to discover a cascade of other enum-related problems (because I wrote a test case). This PR therefore does all of the following:
* updates the logic in `FieldDeclarationsVisitor` to also consider fields contained inside enums
* preserves all enum constructors in used classes (because enum constants, which are all currently preserved, might use them)
* fixes the logic in `PrunerVisitor#getEnclosingClassName` to also account for enums
* adds two new test cases: `FieldInEnumTest` for the crash, and `UnrelatedEnumTest` to check that my enum constructor preservation technique doesn't preserve _all_ enum constructors (just those in classes that would otherwise be preserved)