### PR TITLE
Handle synthetic types that extend Throwable

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
+++ b/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
@@ -45,7 +45,7 @@ class JavaTypeCorrect {
   private Map<String, Set<String>> fileAndAssociatedTypes = new HashMap<>();
 
   /** Synthetic types that need to extend Throwable. */
-  private Set<String> typesToExtendsThrowable = new HashSet<>();
+  private Set<String> typesThatExtendThrowable = new HashSet<>();
 
   /**
    * Create a new JavaTypeCorrect instance. The directories of files in fileNameList are relative to
@@ -76,10 +76,10 @@ class JavaTypeCorrect {
   /**
    * Get the names of synthetic classes that should extend Throwable.
    *
-   * @return the value of typesToExtendsThrowable.
+   * @return the value of typesThatExtendThrowable.
    */
-  public Set<String> getTypesToExtendsThrowable() {
-    return typesToExtendsThrowable;
+  public Set<String> getTypesThatExtendThrowable() {
+    return typesThatExtendThrowable;
   }
 
   /**
@@ -170,7 +170,7 @@ class JavaTypeCorrect {
       String incorrectType = splitErrorMessage.get(4);
       String correctType = splitErrorMessage.get(splitErrorMessage.size() - 1);
       if (correctType.equals("Throwable")) {
-        typesToExtendsThrowable.add(incorrectType);
+        typesThatExtendThrowable.add(incorrectType);
       } else {
         typeToChange.put(incorrectType, tryResolveFullyQualifiedType(correctType, filePath));
       }

--- a/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
+++ b/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
@@ -44,7 +44,11 @@ class JavaTypeCorrect {
    */
   private Map<String, Set<String>> fileAndAssociatedTypes = new HashMap<>();
 
-  /** Synthetic types that need to extend Throwable. */
+  /** 
+    * Synthetic types that need to extend Throwable. Note that the stored Strings are simple names,
+    * which is safe because the worst thing that might happen is that an extra sythetic class might
+    * accidentally extend Throwable.
+    */
   private Set<String> typesThatExtendThrowable = new HashSet<>();
 
   /**

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -199,7 +199,7 @@ public class SpeciminRunner {
     typeCorrecter.correctTypesForAllFiles();
     Map<String, String> typesToChange = typeCorrecter.getTypeToChange();
     addMissingClass.updateTypes(typesToChange);
-    addMissingClass.updateTypesToExtendThrowable(typeCorrecter.getTypesToExtendsThrowable());
+    addMissingClass.updateTypesToExtendThrowable(typeCorrecter.getTypesThatExtendThrowable());
 
     for (String directory : relatedClass) {
       // directories already in parsedTargetFiles are original files in the root directory, we are

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -199,6 +199,7 @@ public class SpeciminRunner {
     typeCorrecter.correctTypesForAllFiles();
     Map<String, String> typesToChange = typeCorrecter.getTypeToChange();
     addMissingClass.updateTypes(typesToChange);
+    addMissingClass.updateTypesToExtendThrowable(typeCorrecter.getTypesToExtendsThrowable());
 
     for (String directory : relatedClass) {
       // directories already in parsedTargetFiles are original files in the root directory, we are

--- a/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
@@ -42,6 +42,9 @@ public class UnsolvedClassOrInterface {
   /** This field records if the class is a custom exception */
   private boolean isExceptionType = false;
 
+  /** The field records if the class extends Throwable type. */
+  private boolean isThrowable = false;
+
   /** This field records if the class is an interface */
   private final boolean isAnInterface;
 
@@ -145,6 +148,11 @@ public class UnsolvedClassOrInterface {
    */
   public Set<String> getClassFields() {
     return classFields;
+  }
+
+  /** Set isThrowable to true. */
+  public void setThrowableToTrue() {
+    isThrowable = true;
   }
 
   /**
@@ -275,6 +283,8 @@ public class UnsolvedClassOrInterface {
     }
     if (isExceptionType) {
       sb.append(" extends Exception");
+    } else if (isThrowable) {
+      sb.append(" extends Throwable");
     }
     sb.append(" {\n");
     for (String variableDeclarations : classFields) {

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -2276,6 +2276,30 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   }
 
   /**
+   * Based on the set returned by JavaTypeCorrect, this method corrects the Throwable extension for
+   * synthetic classes as needed.
+   *
+   * @param typesToExtendThrowable the set of synthetic types that need Throwable extension.
+   */
+  public void updateTypesToExtendThrowable(Set<String> typesToExtendThrowable) {
+    for (String typeToExtendThrowable : typesToExtendThrowable) {
+      Iterator<UnsolvedClassOrInterface> iterator = missingClass.iterator();
+      while (iterator.hasNext()) {
+        UnsolvedClassOrInterface missedClass = iterator.next();
+        // Class comparison is based on class name and package name only.
+        if (missedClass.getClassName().equals(typeToExtendThrowable)) {
+          iterator.remove(); // Remove the outdated version of this synthetic class from the list
+          missedClass.setThrowableToTrue();
+          missingClass.add(missedClass); // Add the modified missedClass back to the list
+          this.deleteOldSyntheticClass(missedClass);
+          this.createMissingClass(missedClass);
+          return;
+        }
+      }
+    }
+  }
+
+  /**
    * Updates the types for fields or methods in a synthetic class.
    *
    * @param className The name of the synthetic class.

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -2282,21 +2282,23 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    * @param typesToExtendThrowable the set of synthetic types that need Throwable extension.
    */
   public void updateTypesToExtendThrowable(Set<String> typesToExtendThrowable) {
+    Set<UnsolvedClassOrInterface> modifiedClasses = new HashSet<>();
+
     for (String typeToExtendThrowable : typesToExtendThrowable) {
       Iterator<UnsolvedClassOrInterface> iterator = missingClass.iterator();
       while (iterator.hasNext()) {
         UnsolvedClassOrInterface missedClass = iterator.next();
-        // Class comparison is based on class name and package name only.
         if (missedClass.getClassName().equals(typeToExtendThrowable)) {
-          iterator.remove(); // Remove the outdated version of this synthetic class from the list
+          iterator.remove();
           missedClass.setThrowableToTrue();
-          missingClass.add(missedClass); // Add the modified missedClass back to the list
+          modifiedClasses.add(missedClass);
           this.deleteOldSyntheticClass(missedClass);
           this.createMissingClass(missedClass);
-          return;
         }
       }
     }
+
+    missingClass.addAll(modifiedClasses);
   }
 
   /**

--- a/src/test/java/org/checkerframework/specimin/ThrowableImprecisionTest.java
+++ b/src/test/java/org/checkerframework/specimin/ThrowableImprecisionTest.java
@@ -7,7 +7,9 @@ import org.junit.Test;
  * This test demonstrates the imprecision of Specimin when there are two or more synthetic classes
  * with the same name. If only one or some of them extend Throwable, Specimin will imprecisely make
  * all of them extend Throwable. This occurs due to Specimin becoming confused when faced with
- * multiple synthetic classes sharing the same name.
+ * multiple synthetic classes sharing the same name. This imprecision is caused by the fact that
+ * Specimin uses javac's error messages to determine which synthetic types need to extend Throwable,
+ * but javac only prints simple names in its error messages.
  */
 public class ThrowableImprecisionTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/ThrowableImprecisionTest.java
+++ b/src/test/java/org/checkerframework/specimin/ThrowableImprecisionTest.java
@@ -4,16 +4,17 @@ import java.io.IOException;
 import org.junit.Test;
 
 /**
- * This test checks that two simple Java files, one of which has a dependency on the other, are
- * reduced correctly. There is one extraneous constructor in the file that doesn't have the target
- * method that ought to be removed.
+ * This test demonstrates the imprecision of Specimin when there are two or more synthetic classes
+ * with the same name. If only one or some of them extend Throwable, Specimin will imprecisely make
+ * all of them extend Throwable. This occurs due to Specimin becoming confused when faced with
+ * multiple synthetic classes sharing the same name.
  */
-public class TwoFileSimpleTest {
+public class ThrowableImprecisionTest {
   @Test
   public void runTest() throws IOException {
     SpeciminTestExecutor.runTestWithoutJarPaths(
-        "twofilesimple",
+        "ThrowableImprecision",
         new String[] {"com/example/Foo.java", "com/example/Baz.java"},
-        new String[] {"com.example.Foo#bar()"});
+        new String[] {"com.example.Foo#bar()", "com.example.Baz#bar()"});
   }
 }

--- a/src/test/java/org/checkerframework/specimin/ThrowableImprecisionTest.java
+++ b/src/test/java/org/checkerframework/specimin/ThrowableImprecisionTest.java
@@ -1,0 +1,19 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that two simple Java files, one of which has a dependency on the other, are
+ * reduced correctly. There is one extraneous constructor in the file that doesn't have the target
+ * method that ought to be removed.
+ */
+public class TwoFileSimpleTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "twofilesimple",
+        new String[] {"com/example/Foo.java", "com/example/Baz.java"},
+        new String[] {"com.example.Foo#bar()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/ThrowableTypeTest.java
+++ b/src/test/java/org/checkerframework/specimin/ThrowableTypeTest.java
@@ -1,0 +1,15 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test checks if Specimin can create synthetic classes that extends Throwable type. */
+public class ThrowableTypeTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "ThrowableType",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/ThrowableImprecision/expected/com/example/Baz.java
+++ b/src/test/resources/ThrowableImprecision/expected/com/example/Baz.java
@@ -3,6 +3,7 @@ package com.example;
 import org.testing.UnsolvedType;
 
 public class Baz {
+
     public void bar() {
         throw new UnsolvedType();
     }

--- a/src/test/resources/ThrowableImprecision/expected/com/example/Baz.java
+++ b/src/test/resources/ThrowableImprecision/expected/com/example/Baz.java
@@ -4,7 +4,7 @@ import org.testing.UnsolvedType;
 
 public class Baz {
 
-    public void bar() {
+    public void bar() throws UnsolvedType {
         throw new UnsolvedType();
     }
 }

--- a/src/test/resources/ThrowableImprecision/expected/com/example/Foo.java
+++ b/src/test/resources/ThrowableImprecision/expected/com/example/Foo.java
@@ -1,7 +1,9 @@
 package com.example;
 
 import org.fortest.UnsolvedType;
+
 class Foo {
+
     void bar() {
         return UnsolvedType.getType();
     }

--- a/src/test/resources/ThrowableImprecision/expected/com/example/Foo.java
+++ b/src/test/resources/ThrowableImprecision/expected/com/example/Foo.java
@@ -4,7 +4,7 @@ import org.fortest.UnsolvedType;
 
 class Foo {
 
-    void bar() {
+    int bar() {
         return UnsolvedType.getType();
     }
 }

--- a/src/test/resources/ThrowableImprecision/expected/org/fortest/OrgFortestUnsolvedTypeGetTypeReturnType.java
+++ b/src/test/resources/ThrowableImprecision/expected/org/fortest/OrgFortestUnsolvedTypeGetTypeReturnType.java
@@ -1,4 +1,0 @@
-package org.fortest;
-
-public class OrgFortestUnsolvedTypeGetTypeReturnType {
-}

--- a/src/test/resources/ThrowableImprecision/expected/org/fortest/OrgFortestUnsolvedTypeGetTypeReturnType.java
+++ b/src/test/resources/ThrowableImprecision/expected/org/fortest/OrgFortestUnsolvedTypeGetTypeReturnType.java
@@ -1,0 +1,4 @@
+package org.fortest;
+
+public class OrgFortestUnsolvedTypeGetTypeReturnType {
+}

--- a/src/test/resources/ThrowableImprecision/expected/org/fortest/UnsolvedType.java
+++ b/src/test/resources/ThrowableImprecision/expected/org/fortest/UnsolvedType.java
@@ -1,0 +1,8 @@
+package org.fortest;
+
+public class UnsolvedType extends Throwable {
+
+    public static OrgFortestUnsolvedTypeGetTypeReturnType getType() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/ThrowableImprecision/expected/org/fortest/UnsolvedType.java
+++ b/src/test/resources/ThrowableImprecision/expected/org/fortest/UnsolvedType.java
@@ -2,7 +2,7 @@ package org.fortest;
 
 public class UnsolvedType extends Throwable {
 
-    public static OrgFortestUnsolvedTypeGetTypeReturnType getType() {
+    public static int getType() {
         throw new Error();
     }
 }

--- a/src/test/resources/ThrowableImprecision/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/ThrowableImprecision/expected/org/testing/UnsolvedType.java
@@ -1,0 +1,8 @@
+package org.testing;
+
+public class UnsolvedType extends Throwable {
+
+    public UnsolvedType() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/ThrowableImprecision/input/com/example/Baz.java
+++ b/src/test/resources/ThrowableImprecision/input/com/example/Baz.java
@@ -3,7 +3,7 @@ package com.example;
 import org.testing.UnsolvedType;
 
 public class Baz {
-    public void bar() {
+    public void bar() throws UnsolvedType {
         throw new UnsolvedType();
     }
 }

--- a/src/test/resources/ThrowableImprecision/input/com/example/Baz.java
+++ b/src/test/resources/ThrowableImprecision/input/com/example/Baz.java
@@ -1,0 +1,12 @@
+package com.example;
+
+public class Baz {
+    public Baz(String s) {
+
+    }
+
+    public Baz() {
+        System.out.println("This constructor is never used, " +
+                "so this ought to be removed by Specimin.");
+    }
+}

--- a/src/test/resources/ThrowableImprecision/input/com/example/Foo.java
+++ b/src/test/resources/ThrowableImprecision/input/com/example/Foo.java
@@ -1,0 +1,7 @@
+package com.example;
+
+class Foo {
+    void bar() {
+        Baz obj = new Baz("hello");
+    }
+}

--- a/src/test/resources/ThrowableImprecision/input/com/example/Foo.java
+++ b/src/test/resources/ThrowableImprecision/input/com/example/Foo.java
@@ -2,7 +2,7 @@ package com.example;
 
 import org.fortest.UnsolvedType;
 class Foo {
-    void bar() {
+    int bar() {
         return UnsolvedType.getType();
     }
 }

--- a/src/test/resources/ThrowableType/expected/com/example/Simple.java
+++ b/src/test/resources/ThrowableType/expected/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.testing.UnsolvedType;
+
+class Simple {
+
+    void bar() throws UnsolvedType {
+        throw new UnsolvedType();
+    }
+}

--- a/src/test/resources/ThrowableType/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/ThrowableType/expected/org/testing/UnsolvedType.java
@@ -1,0 +1,8 @@
+package org.testing;
+
+public class UnsolvedType extends Throwable {
+
+    public UnsolvedType() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/ThrowableType/input/com/example/Simple.java
+++ b/src/test/resources/ThrowableType/input/com/example/Simple.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import org.testing.UnsolvedType;
+
+class Simple {
+    void bar() throws UnsolvedType {
+        throw new UnsolvedType();
+    }
+}


### PR DESCRIPTION
Professor,

This PR addresses the issue that some synthetic types need to extend `Throwable` in order for the output to compile.

Please take a look. Thank you.