### PR TITLE
Adding dependencies in the Specimin build jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,9 @@ repositories {
     mavenLocal()
 }
 
+mainClassName = 'org.checkerframework.specimin.SpeciminRunner'
 application {
-    mainClass = 'org.checkerframework.specimin.SpeciminRunner'
+    mainClass = mainClassName
 }
 
 dependencies {
@@ -88,6 +89,16 @@ spotless {
 compileJava {
     options.compilerArgs += ['-Werror']
 }
+
+jar {
+    manifest {
+        attributes 'Main-Class': mainClassName
+    }
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+}
+
 
 compileJava.dependsOn 'spotlessApply'
 check.dependsOn requireJavadoc

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,8 @@ repositories {
     mavenLocal()
 }
 
-mainClassName = 'org.checkerframework.specimin.SpeciminRunner'
 application {
-    mainClass = mainClassName
+    mainClass = 'org.checkerframework.specimin.SpeciminRunner'
 }
 
 dependencies {
@@ -92,7 +91,7 @@ compileJava {
 
 jar {
     manifest {
-        attributes 'Main-Class': mainClassName
+        attributes 'Main-Class': 'org.checkerframework.specimin.SpeciminRunner'
     }
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,6 @@ jar {
     }
 }
 
-
 compileJava.dependsOn 'spotlessApply'
 check.dependsOn requireJavadoc
 

--- a/src/test/resources/MethodInEnum/expected/com/example/Foo.java
+++ b/src/test/resources/MethodInEnum/expected/com/example/Foo.java
@@ -6,13 +6,13 @@ class Foo {
 
         ON {
 
-            public static void testing() {
+            public void testing() {
                 throw new Error();
             }
         }
         , OFF {
 
-            public static void testing() {
+            public void testing() {
                 throw new Error();
             }
         }

--- a/src/test/resources/MethodInEnum/input/com/example/Foo.java
+++ b/src/test/resources/MethodInEnum/input/com/example/Foo.java
@@ -4,12 +4,12 @@ class Foo {
 
     private enum STATUS{
         ON {
-            public static void testing() {
+            public void testing() {
                 throw new RuntimeException();
             }
         },
         OFF {
-            public static void testing() {
+            public void testing() {
                 throw new RuntimeException();
             }
         };

--- a/src/test/resources/existingclasswithunsolvedsuperclass/expected/com/example/Foo.java
+++ b/src/test/resources/existingclasswithunsolvedsuperclass/expected/com/example/Foo.java
@@ -7,6 +7,6 @@ class Foo {
     Map<Baz, String> field;
 
     boolean bar() {
-        field.isEmpty();
+        return field.isEmpty();
     }
 }

--- a/src/test/resources/existingclasswithunsolvedsuperclass/input/com/example/Foo.java
+++ b/src/test/resources/existingclasswithunsolvedsuperclass/input/com/example/Foo.java
@@ -5,6 +5,6 @@ import java.util.Map;
 class Foo {
     Map<Baz, String> field;
     boolean bar() {
-        field.isEmpty();
+        return field.isEmpty();
     }
 }

--- a/src/test/resources/fieldtoempty/expected/com/example/Simple.java
+++ b/src/test/resources/fieldtoempty/expected/com/example/Simple.java
@@ -8,6 +8,6 @@ class Simple {
 
     void test() {
         c++;
-        b++;
+        int d = b + 1;
     }
 }

--- a/src/test/resources/fieldtoempty/input/com/example/Simple.java
+++ b/src/test/resources/fieldtoempty/input/com/example/Simple.java
@@ -10,6 +10,6 @@ class Simple {
     }
     void test() {
         c++;
-        b++;
+        int d = b + 1;
     }
 }

--- a/src/test/resources/implicitinterfaceaccess/expected/org/testing/B.java
+++ b/src/test/resources/implicitinterfaceaccess/expected/org/testing/B.java
@@ -2,5 +2,7 @@ package org.testing;
 
 public interface B {
 
-    public int baz();
+    public default int baz() {
+        throw new Error();
+    }
 }

--- a/src/test/resources/implicitinterfaceaccessmethodoverload/expected/org/testing/B.java
+++ b/src/test/resources/implicitinterfaceaccessmethodoverload/expected/org/testing/B.java
@@ -2,5 +2,7 @@ package org.testing;
 
 public interface B {
 
-    public FooReturnType foo(int parameter0, java.lang.String parameter1);
+    public default FooReturnType foo(int parameter0, java.lang.String parameter1) {
+        throw new Error();
+    }
 }

--- a/src/test/resources/implicitinterfaceaccesswithmanyinterfaces/expected/org/testing/D.java
+++ b/src/test/resources/implicitinterfaceaccesswithmanyinterfaces/expected/org/testing/D.java
@@ -2,5 +2,7 @@ package org.testing;
 
 public interface D {
 
-    public int baz();
+    public default int baz() {
+        throw new Error();
+    }
 }

--- a/src/test/resources/interfaceimplemented/expected/com/example/Baz.java
+++ b/src/test/resources/interfaceimplemented/expected/com/example/Baz.java
@@ -2,5 +2,7 @@ package com.example;
 
 public interface Baz {
 
-    void doSomething();
+    default void doSomething() {
+        throw new Error();
+    }
 }

--- a/src/test/resources/interfacemethodwithunsolvedtype/expected/com/example/Baz.java
+++ b/src/test/resources/interfacemethodwithunsolvedtype/expected/com/example/Baz.java
@@ -4,5 +4,7 @@ import org.testing.UnsolvedType;
 
 public interface Baz<T> {
 
-    UnsolvedType doSomething(T value);
+    default UnsolvedType doSomething(T value) {
+        throw new Error();
+    }
 }

--- a/src/test/resources/interfacemethodwithunsolvedtype/expected/com/example/Foo.java
+++ b/src/test/resources/interfacemethodwithunsolvedtype/expected/com/example/Foo.java
@@ -7,5 +7,6 @@ class Foo implements Baz<String> {
     @Override
     public UnsolvedType doSomething(String value) {
         System.out.println("Foo is doing something with: " + value);
+        return null;
     }
 }

--- a/src/test/resources/interfacemethodwithunsolvedtype/input/com/example/Foo.java
+++ b/src/test/resources/interfacemethodwithunsolvedtype/input/com/example/Foo.java
@@ -6,6 +6,7 @@ class Foo implements Baz<String> {
     @Override
     public UnsolvedType doSomething(String value) {
         System.out.println("Foo is doing something with: " + value);
+        return null;
     }
 
 }

--- a/src/test/resources/interfacewithgenerictype/expected/com/example/Baz.java
+++ b/src/test/resources/interfacewithgenerictype/expected/com/example/Baz.java
@@ -2,7 +2,11 @@ package com.example;
 
 public interface Baz<T> {
 
-    void doSomething(T value);
+    default void doSomething(T value) {
+        throw new Error();
+    }
 
-    void doSomething(int x);
+    default void doSomething(int x) {
+        throw new Error();
+    }
 }

--- a/src/test/resources/interfacewithunsolvedsymbols/expected/com/example/Baz.java
+++ b/src/test/resources/interfacewithunsolvedsymbols/expected/com/example/Baz.java
@@ -2,7 +2,11 @@ package com.example;
 
 public interface Baz<T> {
 
-    void doSomething(T value);
+    default void doSomething(T value) {
+        throw new Error();
+    }
 
-    void doSomething(int x);
+    default void doSomething(int x) {
+        throw new Error();
+    }
 }

--- a/src/test/resources/sameclassname/expected/org/second/Calculator.java
+++ b/src/test/resources/sameclassname/expected/org/second/Calculator.java
@@ -1,6 +1,6 @@
 package org.second;
 
-class Calculator {
+public class Calculator {
     public Calculator() {
         throw new Error();
     }

--- a/src/test/resources/sameclassname/input/org/second/Calculator.java
+++ b/src/test/resources/sameclassname/input/org/second/Calculator.java
@@ -1,6 +1,6 @@
 package org.second;
 
-class Calculator {
+public class Calculator {
     public Calculator() {
 
     }

--- a/typecheck_test_outputs.sh
+++ b/typecheck_test_outputs.sh
@@ -26,4 +26,6 @@ elif [ "${returnval}" = 2 ]; then
   echo "Some expected test outputs do not compile successfully. See the above error output for details."
 fi
 
+find . -name "*.class" -exec rm {} \;
+
 exit ${returnval}

--- a/typecheck_test_outputs.sh
+++ b/typecheck_test_outputs.sh
@@ -15,7 +15,7 @@ for testcase in * ; do
     cd "${testcase}/expected/" || exit 1
     # javac relies on word splitting
     # shellcheck disable=SC2046
-    javac -proc:only -nowarn -classpath "../../shared/checker-qual-3.42.0.jar" $(find . -name "*.java") \
+    javac -classpath "../../shared/checker-qual-3.42.0.jar" $(find . -name "*.java") \
       || { echo "Running javac on ${testcase}/expected issues one or more errors, which are printed above."; returnval=2; }
     cd ../.. || exit 1
 done


### PR DESCRIPTION
The default jar does not contain the dependent class files. It throws `ClassNotFoundException`. 