### PR TITLE
adding dependency in target jar file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,15 @@ compileJava {
     options.compilerArgs += ['-Werror']
 }
 
+jar {
+    manifest {
+        attributes 'Main-Class': 'org.checkerframework.specimin.SpeciminRunner'
+    }
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+}
+
 compileJava.dependsOn 'spotlessApply'
 check.dependsOn requireJavadoc
 


### PR DESCRIPTION
Dependent lib class are not included in the specimin jar file currently. Which causes ClassNotFound exception when running the project from jar. 