### PR TITLE
Debug logic for infinite loops

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -916,7 +916,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
               + typeExpr.getNameAsString();
       if (classfileIsInOriginalCodebase(qualifiedName)) {
         addedTargetFiles.add(qualifiedNameToFilePath(qualifiedName));
-        gotException = true;
+        gotException();
         return super.visit(typeExpr, p);
       }
 
@@ -947,7 +947,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       }
       classToUpdate.setNumberOfTypeVariables(numberOfArguments);
       updateMissingClass(classToUpdate);
-      gotException = true;
+      gotException();
     }
     return super.visit(typeExpr, p);
   }
@@ -975,7 +975,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     catch (UnsolvedSymbolException | UnsupportedOperationException e) {
       if (!parameter.getType().isUnknownType()) {
         handleParameterResolveFailure(parameter);
-        gotException = true;
+        gotException();
       }
     }
     return super.visit(parameter, p);

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -80,6 +80,12 @@ import org.checkerframework.checker.signature.qual.FullyQualifiedName;
 public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
 
   /**
+   * Flag for whether or not to print debugging output. Should always be false except when you
+   * are actively debugging.
+   */
+  private static final boolean DEBUG = false;
+
+  /**
    * This map associates class names with their respective superclasses. The keys in this map
    * represent the classes of the currently visited file. Due to the potential presence of inner
    * classes, there may be multiple pairs of class and superclass entries in this map. This map can
@@ -399,7 +405,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
           // strictly speaking, there is no exception here. But we set gotException to true so that
           // UnsolvedSymbolVisitor will run at least one more iteration to visit the newly added
           // file.
-          this.gotException = true;
+          gotException();
         }
         addedTargetFiles.add(filePath);
       } else {
@@ -647,11 +653,11 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
           nameExprReferenceType.getAllAncestors();
           // check if all the type parameters are resolved.
           if (!hasResolvedTypeParameters(nameExprReferenceType)) {
-            this.gotException = true;
+            gotException();
           }
         }
       } catch (UnsolvedSymbolException e) {
-        this.gotException = true;
+        gotException();
       }
       return super.visit(node, arg);
     }
@@ -786,7 +792,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       // for a qualified name field access such as org.sample.MyClass.field, org.sample will also be
       // considered FieldAccessExpr.
       if (isAClassPath(node.getScope().toString())) {
-        this.gotException = true;
+        gotException();
       }
     }
     return super.visit(node, p);
@@ -855,7 +861,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
             || calledByAnIncompleteClass(method)
             || isAnUnsolvedStaticMethodCalledByAQualifiedClassName(method);
     if (needToSetException) {
-      this.gotException = true;
+      gotException();
     }
     return super.visit(method, p);
   }
@@ -983,7 +989,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       }
       return super.visit(newExpr, p);
     }
-    this.gotException = true;
+    gotException();
     try {
       List<String> argumentsCreation = getArgumentsFromObjectCreation(newExpr);
       UnsolvedMethod creationMethod = new UnsolvedMethod("", type, argumentsCreation);
@@ -2350,5 +2356,17 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     } else {
       throw new RuntimeException("Unfound parent for this class: " + className);
     }
+  }
+
+  /**
+   * This indirection is here to make it easier to debug infinite loops.
+   * Never set gotException directly, but instead call this function.
+   */
+  private void gotException() {
+    if (DEBUG) {
+      StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+      System.out.println("setting gotException to true from: " + stackTraceElements[1]);
+    }
+    this.gotException = true;
   }
 }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -2365,7 +2365,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   private void gotException() {
     if (DEBUG) {
       StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
-      System.out.println("setting gotException to true from: " + stackTraceElements[1]);
+      System.out.println("setting gotException to true from: " + stackTraceElements[2]);
     }
     this.gotException = true;
   }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -855,12 +855,17 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         }
       }
     }
-    boolean needToSetException =
-        !canBeSolved(method)
-            || calledByAnUnsolvedSymbol(method)
-            || calledByAnIncompleteClass(method)
-            || isAnUnsolvedStaticMethodCalledByAQualifiedClassName(method);
-    if (needToSetException) {
+        
+    // Though this structure looks a bit silly, it is intentional
+    // that these 4 calls to getException() produce different stacktraces,
+    // which is very helpful for debugging infinite loops.
+    if (!canBeSolved(method)) {
+      gotException();
+    } else if (calledByAnUnsolvedSymbol(method)) {
+      gotException();
+    } else if (calledByAnIncompleteClass(method)) {
+      gotException();
+    } else if (isAnUnsolvedStaticMethodCalledByAQualifiedClassName(method)) {
       gotException();
     }
     return super.visit(method, p);


### PR DESCRIPTION
This is the second time I've had to write this logic, so I figured we should include it in UnsolvedSymbolVisitor directly. It shouldn't have a perf impact as long as `DEBUG` is false, but it makes it easy to switch it on when it's needed (when debugging an infinite loop caused by `gotException` being set to true even though nothing is changing).