### PR TITLE
Add check for infinite loop

### DIFF
--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -125,7 +125,15 @@ public class SpeciminRunner {
     // The set of path of files that have been created by addMissingClass. We will delete all those
     // files in the end.
     Set<Path> createdClass = new HashSet<>();
+    // Set containing paths of files created by all runs of addMissingClass before the current one.
+    Set<Path> createdFilesLastRun = new HashSet<>();
     while (addMissingClass.gettingException()) {
+      if (!createdFilesLastRun.isEmpty()) {
+        if (createdClass.equals(createdFilesLastRun)) {
+          throw new RuntimeException("UnsolvedSymbolVisitor is not making any progress.");
+        }
+        createdFilesLastRun = createdClass;
+      }
       addMissingClass.setExceptionToFalse();
       for (CompilationUnit cu : parsedTargetFiles.values()) {
         addMissingClass.setImportStatement(cu.getImports());

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -125,15 +125,7 @@ public class SpeciminRunner {
     // The set of path of files that have been created by addMissingClass. We will delete all those
     // files in the end.
     Set<Path> createdClass = new HashSet<>();
-    // Set containing paths of files created by all runs of addMissingClass before the current one.
-    Set<Path> createdFilesLastRun = new HashSet<>();
     while (addMissingClass.gettingException()) {
-      if (!createdFilesLastRun.isEmpty()) {
-        if (createdClass.equals(createdFilesLastRun)) {
-          throw new RuntimeException("UnsolvedSymbolVisitor is not making any progress.");
-        }
-        createdFilesLastRun = createdClass;
-      }
       addMissingClass.setExceptionToFalse();
       for (CompilationUnit cu : parsedTargetFiles.values()) {
         addMissingClass.setImportStatement(cu.getImports());
@@ -158,6 +150,13 @@ public class SpeciminRunner {
       }
       for (String targetFile : addMissingClass.getAddedTargetFiles()) {
         parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
+      }
+      if (addMissingClass.gettingException()) {
+        if (addMissingClass.hasMadeProgress()) {
+          addMissingClass.setMakeProgressToFalse();
+        } else {
+          throw new RuntimeException("UnsolvedSymbolVisitor is stuck at one or more exception!");
+        }
       }
     }
 

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -669,6 +669,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     }
     String name = node.getNameAsString();
     if (fieldNameToClassNameMap.containsKey(name)) {
+      boolean newlyFoundField = !potentialUsedMembers.contains(name);
       potentialUsedMembers.add(name);
       try {
         // check if the type is resolved and does not extend any unresolved type.
@@ -682,7 +683,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
             // while no new files are added, this is actually a progress, because we have detected
             // one unsolved field that is used by a target method and need to be resolved in the
             // next iteration.
-            makeProgress = true;
+            if (newlyFoundField) {
+              makeProgress = true;
+            }
           }
         }
       } catch (UnsolvedSymbolException e) {
@@ -690,7 +693,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         // while no new files are added, this is actually a progress, because we have detected
         // one unsolved field that is used by a target method and need to be resolved in the next
         // iteration.
-        makeProgress = true;
+        if (newlyFoundField) {
+          makeProgress = true;
+        }
       }
       return super.visit(node, arg);
     }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -679,10 +679,18 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
           // check if all the type parameters are resolved.
           if (!hasResolvedTypeParameters(nameExprReferenceType)) {
             gotException();
+            // while no new files are added, this is actually a progress, because we have detected
+            // one unsolved field that is used by a target method and need to be resolved in the
+            // next iteration.
+            makeProgress = true;
           }
         }
       } catch (UnsolvedSymbolException e) {
         gotException();
+        // while no new files are added, this is actually a progress, because we have detected
+        // one unsolved field that is used by a target method and need to be resolved in the next
+        // iteration.
+        makeProgress = true;
       }
       return super.visit(node, arg);
     }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -352,6 +352,8 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   /**
    * Check if UnsolvedSymbolVisitor has made any progress. This method should be called at the end
    * of each iteration.
+   *
+   * @return makeProgress.
    */
   public boolean hasMadeProgress() {
     return makeProgress;

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1891,6 +1891,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     if (classfileIsInOriginalCodebase(qualifiedName)) {
       return;
     }
+    if (!missingClass.contains(missedClass)) {
+      makeProgress = true;
+    }
     Iterator<UnsolvedClassOrInterface> iterator = missingClass.iterator();
     while (iterator.hasNext()) {
       UnsolvedClassOrInterface e = iterator.next();
@@ -1919,8 +1922,6 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
           e.setNumberOfTypeVariables(missedClass.getNumberOfTypeVariables());
         }
         return;
-      } else {
-        makeProgress = true;
       }
     }
     missingClass.add(missedClass);

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -222,7 +222,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
 
   /**
    * This field checks if UnsolvedSymbolVisitor is making any progress. If it is not making any
-   * progress after finishing one iteration, then it is in an infinite loop.
+   * progress and gotException is set to true, then we're having an infinite loop.
    */
   private boolean makeProgress = false;
 


### PR DESCRIPTION
Professor,

This is the PR to get Specimin to throw an exception whenever `UnsolvedSymbolVisitor` is stuck. While the error message is not very useful, I think it's convenient to know whenever we are in an infinite loop.

Please take a look. Thank you.