### PR TITLE
Allow Specimin to handle wildcard imports even in non-jar mode

### DIFF
--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.visitor.Visitable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
@@ -87,6 +88,17 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
     this.methodsToLeaveUnchanged = methodsToKeep;
     this.membersToEmpty = membersToEmpty;
     this.classesUsedByTargetMethods = classesUsedByTargetMethods;
+    Set<String> toRemove = new HashSet<>();
+    for (String classUsedByTargetMethods : classesUsedByTargetMethods) {
+      if (classUsedByTargetMethods.contains("<")) {
+        toRemove.add(classUsedByTargetMethods);
+      }
+    }
+    for (String s : toRemove) {
+      classesUsedByTargetMethods.remove(s);
+      String withoutAngleBrackets = s.substring(0, s.indexOf("<"));
+      classesUsedByTargetMethods.add(withoutAngleBrackets);
+    }
   }
 
   @Override

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -97,12 +97,12 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
       // the result of getNameAsString is actually the package name. This renaming is just to
       // make the code less confusing.
       String importedPackage = classFullName;
+      // the parent of an import is always the corresponding compilation unit, thanks to the
+      // JLS' requirements about the placement of import statements (JLS 7.3)
       CompilationUnit parent = (CompilationUnit) decl.getParentNode().orElseThrow();
       decl.remove();
       for (String usedClassFQN : classesUsedByTargetMethods) {
         if (usedClassFQN.startsWith(importedPackage)) {
-          // the parent of an import is always the corresponding compilation unit, thanks to the
-          // JLS' requirements about the placement of import statements
           parent.addImport(usedClassFQN);
         }
       }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -429,7 +429,14 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       if (classfileIsInOriginalCodebase(qualifiedName)) {
         // add the source codes of the interface or the super class to the list of target files so
         // that UnsolvedSymbolVisitor can solve symbols for that class if needed.
-        addToListOfTargetFiles(qualifiedName);
+        String filePath = qualifiedNameToFilePath(qualifiedName);
+        if (!addedTargetFiles.contains(filePath)) {
+          // strictly speaking, there is no exception here. But we set gotException to true so that
+          // UnsolvedSymbolVisitor will run at least one more iteration to visit the newly added
+          // file.
+          gotException();
+        }
+        addedTargetFiles.add(filePath);
       } else {
         try {
           implementedOrExtended.resolve();
@@ -471,23 +478,6 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       this.currentClassQualifiedName = "";
     }
     return result;
-  }
-
-  /**
-   * Helper method to add the file for the class specificed by the given qualified name to the list
-   * of added target files.
-   *
-   * @param qualifiedName a fully-qualified name of a class that exists in the original codebase
-   */
-  private void addToListOfTargetFiles(String qualifiedName) {
-    String filePath = qualifiedNameToFilePath(qualifiedName);
-    if (!addedTargetFiles.contains(filePath)) {
-      // strictly speaking, there is no exception here. But we set gotException to true so that
-      // UnsolvedSymbolVisitor will run at least one more iteration to visit the newly added
-      // file.
-      gotException();
-    }
-    addedTargetFiles.add(filePath);
   }
 
   @Override
@@ -949,7 +939,6 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       // UnsolvedSymbolVisitor will take care of the unsolved extension in its next iteration.
       String qualifiedName =
           getPackageFromClassName(typeExpr.getNameAsString()) + "." + typeExpr.getNameAsString();
-
       if (classfileIsInOriginalCodebase(qualifiedName)) {
         addedTargetFiles.add(qualifiedNameToFilePath(qualifiedName));
         gotException();

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -284,10 +284,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       if (importParts.size() > 0) {
         String className = importParts.get(importParts.size() - 1);
         String packageName = importStatement.replace("." + className, "");
-        if (className.equals("*")) {
-          System.out.println("adding this package to wildcard imports (via loc 1): " + packageName);
-          this.wildcardImports.add(packageName);
-        } else {
+        if (!className.equals("*")) {
           this.classAndPackageMap.put(className, packageName);
         }
       }
@@ -380,8 +377,6 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   @Override
   public Node visit(ImportDeclaration decl, Void arg) {
     if (decl.isAsterisk()) {
-      System.out.println(
-          "adding this package to wildcard imports (via loc 2): " + decl.getNameAsString());
       wildcardImports.add(decl.getNameAsString());
     }
     if (decl.isStatic()) {
@@ -434,14 +429,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       if (classfileIsInOriginalCodebase(qualifiedName)) {
         // add the source codes of the interface or the super class to the list of target files so
         // that UnsolvedSymbolVisitor can solve symbols for that class if needed.
-        String filePath = qualifiedNameToFilePath(qualifiedName);
-        if (!addedTargetFiles.contains(filePath)) {
-          // strictly speaking, there is no exception here. But we set gotException to true so that
-          // UnsolvedSymbolVisitor will run at least one more iteration to visit the newly added
-          // file.
-          gotException();
-        }
-        addedTargetFiles.add(filePath);
+        addToListOfTargetFiles(qualifiedName);
       } else {
         try {
           implementedOrExtended.resolve();
@@ -483,6 +471,23 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       this.currentClassQualifiedName = "";
     }
     return result;
+  }
+
+  /**
+   * Helper method to add the file for the class specificed by the given qualified name to the list
+   * of added target files.
+   *
+   * @param qualifiedName a fully-qualified name of a class that exists in the original codebase
+   */
+  private void addToListOfTargetFiles(String qualifiedName) {
+    String filePath = qualifiedNameToFilePath(qualifiedName);
+    if (!addedTargetFiles.contains(filePath)) {
+      // strictly speaking, there is no exception here. But we set gotException to true so that
+      // UnsolvedSymbolVisitor will run at least one more iteration to visit the newly added
+      // file.
+      gotException();
+    }
+    addedTargetFiles.add(filePath);
   }
 
   @Override
@@ -660,7 +665,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       else if (!classAndPackageMap.containsKey(typeAsString)) {
         @SuppressWarnings("signature") // since this is the simple name case
         @ClassGetSimpleName String className = typeAsString;
-        String packageName = this.currentPackage;
+        String packageName = getPackageFromClassName(className);
         UnsolvedClassOrInterface newClass = new UnsolvedClassOrInterface(className, packageName);
         updateMissingClass(newClass);
       }
@@ -944,6 +949,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       // UnsolvedSymbolVisitor will take care of the unsolved extension in its next iteration.
       String qualifiedName =
           getPackageFromClassName(typeExpr.getNameAsString()) + "." + typeExpr.getNameAsString();
+
       if (classfileIsInOriginalCodebase(qualifiedName)) {
         addedTargetFiles.add(qualifiedNameToFilePath(qualifiedName));
         gotException();
@@ -1123,8 +1129,8 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       packageName = typeRawName.substring(0, typeRawName.lastIndexOf("."));
       className = typeRawName.substring(typeRawName.lastIndexOf(".") + 1);
     } else {
-      packageName = classAndPackageMap.getOrDefault(typeRawName, currentPackage);
       className = typeRawName;
+      packageName = getPackageFromClassName(className);
     }
     classToUpdate = new UnsolvedClassOrInterface(className, packageName, false, isAnInterface);
 
@@ -1763,39 +1769,33 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    * @return the package of that class.
    */
   public String getPackageFromClassName(String className) {
-    System.out.println("getting package for class: " + className);
     if (className.contains("<")) {
       className = className.substring(0, className.indexOf("<"));
     }
     String pkg = classAndPackageMap.get(className);
     if (pkg != null) {
-      System.out.println("pkg: " + pkg);
       return pkg;
     } else {
       // Check if there is a wildcard import. If there isn't always use
       // currentPackage.
       if (wildcardImports.size() == 0) {
-        System.out.println("no wildcard imports, defaulting to current package");
         return currentPackage;
       }
       // If there is a wildcard import, check if there is a matching class
       // in the original codebase in the current package. If so, use that.
       if (classfileIsInOriginalCodebase(currentPackage + "." + className)) {
-        System.out.println("original codebase has " + currentPackage + "." + className);
         return currentPackage;
       }
       // If not, then check for each wildcard import if the original codebase
       // contains an appropriate class. If so, use it.
       for (String wildcardPkg : wildcardImports) {
         if (classfileIsInOriginalCodebase(wildcardPkg + "." + className)) {
-          System.out.println("original codebase has " + wildcardPkg + "." + className);
           return wildcardPkg;
         }
       }
       // If none do, then default to the first wildcard import.
-      System.out.println(
-          "no original found, defaulting to: " + wildcardImports.get(0) + "." + className);
-      return wildcardImports.get(0);
+      String wildcardPkg = wildcardImports.get(0);
+      return wildcardPkg;
     }
   }
 
@@ -2168,7 +2168,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     }
     String methodCall = method.toString();
     String classCaller = method.getScope().get().toString();
-    String packageOfClass = this.classAndPackageMap.get(classCaller);
+    String packageOfClass = getPackageFromClassName(classCaller);
     return packageOfClass + "." + methodCall;
   }
 

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1783,6 +1783,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         }
       }
       // If none do, then default to the first wildcard import.
+      // TODO: log a warning about this once we have a logger
       String wildcardPkg = wildcardImports.get(0);
       return wildcardPkg;
     }

--- a/src/main/resources/target_status.json
+++ b/src/main/resources/target_status.json
@@ -1,9 +1,9 @@
 {
-  "cf-1291": "FAIL",
-  "cf-6282": "FAIL",
+  "cf-1291": "PASS",
+  "cf-6282": "PASS",
   "cf-6077": "PASS",
   "cf-6060": "PASS",
-  "cf-6030": "FAIL",
+  "cf-6030": "PASS",
   "cf-6030b": "FAIL",
   "cf-6019": "FAIL",
   "cf-4614": "PASS",

--- a/src/test/java/org/checkerframework/specimin/WildcardImport2Test.java
+++ b/src/test/java/org/checkerframework/specimin/WildcardImport2Test.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * This test checks the case where there are two wildcard imports: unsolved classes
+ * are placed in the first one (this is an arbitrary choice, but Specimin has no way
+ * to do better without access to the classpath).
+ */
+public class WildcardImport2Test {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "wildcardimport2",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/WildcardImport2Test.java
+++ b/src/test/java/org/checkerframework/specimin/WildcardImport2Test.java
@@ -1,13 +1,12 @@
 package org.checkerframework.specimin;
 
+import java.io.IOException;
 import org.junit.Test;
 
-import java.io.IOException;
-
 /**
- * This test checks the case where there are two wildcard imports: unsolved classes
- * are placed in the first one (this is an arbitrary choice, but Specimin has no way
- * to do better without access to the classpath).
+ * This test checks the case where there are two wildcard imports: unsolved classes are placed in
+ * the first one (this is an arbitrary choice, but Specimin has no way to do better without access
+ * to the classpath).
  */
 public class WildcardImport2Test {
   @Test

--- a/src/test/java/org/checkerframework/specimin/WildcardImport3Test.java
+++ b/src/test/java/org/checkerframework/specimin/WildcardImport3Test.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * This test checks the case where there are two wildcard imports, but the used class
+ * that one of them refers to is actually in the input. In that case, the output should
+ * use that input class rather than putting it in the wrong place.
+ */
+public class WildcardImport3Test {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "wildcardimport3",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/WildcardImport3Test.java
+++ b/src/test/java/org/checkerframework/specimin/WildcardImport3Test.java
@@ -1,13 +1,12 @@
 package org.checkerframework.specimin;
 
+import java.io.IOException;
 import org.junit.Test;
 
-import java.io.IOException;
-
 /**
- * This test checks the case where there are two wildcard imports, but the used class
- * that one of them refers to is actually in the input. In that case, the output should
- * use that input class rather than putting it in the wrong place.
+ * This test checks the case where there are two wildcard imports, but the used class that one of
+ * them refers to is actually in the input. In that case, the output should use that input class
+ * rather than putting it in the wrong place.
  */
 public class WildcardImport3Test {
   @Test

--- a/src/test/java/org/checkerframework/specimin/WildcardImport4Test.java
+++ b/src/test/java/org/checkerframework/specimin/WildcardImport4Test.java
@@ -1,13 +1,11 @@
 package org.checkerframework.specimin;
 
+import java.io.IOException;
 import org.junit.Test;
 
-import java.io.IOException;
-
 /**
- * This test checks the case where there is a wildcard import, but there is a matching
- * class in the same package as the target class. In that case, the wildcard import should
- * be ignored.
+ * This test checks the case where there is a wildcard import, but there is a matching class in the
+ * same package as the target class. In that case, the wildcard import should be ignored.
  */
 public class WildcardImport4Test {
   @Test

--- a/src/test/java/org/checkerframework/specimin/WildcardImport4Test.java
+++ b/src/test/java/org/checkerframework/specimin/WildcardImport4Test.java
@@ -1,0 +1,20 @@
+package org.checkerframework.specimin;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * This test checks the case where there is a wildcard import, but there is a matching
+ * class in the same package as the target class. In that case, the wildcard import should
+ * be ignored.
+ */
+public class WildcardImport4Test {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "wildcardimport4",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/WildcardImportTest.java
+++ b/src/test/java/org/checkerframework/specimin/WildcardImportTest.java
@@ -1,12 +1,11 @@
 package org.checkerframework.specimin;
 
+import java.io.IOException;
 import org.junit.Test;
 
-import java.io.IOException;
-
 /**
- * This test checks the simplest wildcard import case: there is a single wildcard import,
- * so unsolved classes in the input should be placed there.
+ * This test checks the simplest wildcard import case: there is a single wildcard import, so
+ * unsolved classes in the input should be placed there.
  */
 public class WildcardImportTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/WildcardImportTest.java
+++ b/src/test/java/org/checkerframework/specimin/WildcardImportTest.java
@@ -1,0 +1,19 @@
+package org.checkerframework.specimin;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * This test checks the simplest wildcard import case: there is a single wildcard import,
+ * so unsolved classes in the input should be placed there.
+ */
+public class WildcardImportTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "wildcardimport",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/wildcardimport/expected/com/example/Simple.java
+++ b/src/test/resources/wildcardimport/expected/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.example.Foo;
+
+class Simple {
+    void bar() {
+        Foo obj = new Foo();
+        obj.fooMethod();
+    }
+}

--- a/src/test/resources/wildcardimport/expected/com/example/Simple.java
+++ b/src/test/resources/wildcardimport/expected/com/example/Simple.java
@@ -1,6 +1,7 @@
 package com.example;
 
 import org.example.Foo;
+import org.example.FooMethodReturnType;
 
 class Simple {
     void bar() {

--- a/src/test/resources/wildcardimport/expected/org/example/Foo.java
+++ b/src/test/resources/wildcardimport/expected/org/example/Foo.java
@@ -1,0 +1,7 @@
+package org.example;
+
+public class Foo {
+    FooMethodReturnType fooMethod() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/wildcardimport/expected/org/example/Foo.java
+++ b/src/test/resources/wildcardimport/expected/org/example/Foo.java
@@ -1,7 +1,12 @@
 package org.example;
 
 public class Foo {
-    FooMethodReturnType fooMethod() {
+
+    public Foo() {
+        throw new Error();
+    }
+
+    public FooMethodReturnType fooMethod() {
         throw new Error();
     }
 }

--- a/src/test/resources/wildcardimport/expected/org/example/FooMethodReturnType.java
+++ b/src/test/resources/wildcardimport/expected/org/example/FooMethodReturnType.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public class FooMethodReturnType {
+
+}

--- a/src/test/resources/wildcardimport/input/com/example/Simple.java
+++ b/src/test/resources/wildcardimport/input/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.example.*;
+
+class Simple {
+    // Target method.
+    void bar() {
+        Foo obj = new Foo();
+        obj.fooMethod();
+    }
+}

--- a/src/test/resources/wildcardimport2/expected/com/example/Simple.java
+++ b/src/test/resources/wildcardimport2/expected/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.example.Foo;
+
+class Simple {
+    void bar() {
+        Foo obj = new Foo();
+        obj.fooMethod();
+    }
+}

--- a/src/test/resources/wildcardimport2/expected/com/example/Simple.java
+++ b/src/test/resources/wildcardimport2/expected/com/example/Simple.java
@@ -1,6 +1,7 @@
 package com.example;
 
 import org.example.Foo;
+import org.example.FooMethodReturnType;
 
 class Simple {
     void bar() {

--- a/src/test/resources/wildcardimport2/expected/org/example/Foo.java
+++ b/src/test/resources/wildcardimport2/expected/org/example/Foo.java
@@ -1,0 +1,7 @@
+package org.example;
+
+public class Foo {
+    FooMethodReturnType fooMethod() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/wildcardimport2/expected/org/example/Foo.java
+++ b/src/test/resources/wildcardimport2/expected/org/example/Foo.java
@@ -1,7 +1,12 @@
 package org.example;
 
 public class Foo {
-    FooMethodReturnType fooMethod() {
+
+    public Foo() {
+        throw new Error();
+    }
+
+    public FooMethodReturnType fooMethod() {
         throw new Error();
     }
 }

--- a/src/test/resources/wildcardimport2/expected/org/example/FooMethodReturnType.java
+++ b/src/test/resources/wildcardimport2/expected/org/example/FooMethodReturnType.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public class FooMethodReturnType {
+
+}

--- a/src/test/resources/wildcardimport2/input/com/example/Simple.java
+++ b/src/test/resources/wildcardimport2/input/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+// No way to tell which of these contains Foo, so
+// we default to the first one.
+import org.example.*;
+import org.anotherexample.*;
+
+class Simple {
+    // Target method.
+    void bar() {
+        Foo obj = new Foo();
+        obj.fooMethod();
+    }
+}

--- a/src/test/resources/wildcardimport3/expected/com/example/Simple.java
+++ b/src/test/resources/wildcardimport3/expected/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.example.Foo;
+
+class Simple {
+    void bar() {
+        Foo obj = new Foo();
+        obj.fooMethod();
+    }
+}

--- a/src/test/resources/wildcardimport3/expected/com/example/Simple.java
+++ b/src/test/resources/wildcardimport3/expected/com/example/Simple.java
@@ -1,6 +1,6 @@
 package com.example;
 
-import org.example.Foo;
+import org.anotherexample.Foo;
 
 class Simple {
     void bar() {

--- a/src/test/resources/wildcardimport3/expected/org/anotherexample/Foo.java
+++ b/src/test/resources/wildcardimport3/expected/org/anotherexample/Foo.java
@@ -1,7 +1,7 @@
 package org.anotherexample;
 
 public class Foo {
-    void fooMethod() {
+    public void fooMethod() {
         throw new Error();
     }
 }

--- a/src/test/resources/wildcardimport3/expected/org/anotherexample/Foo.java
+++ b/src/test/resources/wildcardimport3/expected/org/anotherexample/Foo.java
@@ -1,0 +1,7 @@
+package org.anotherexample;
+
+public class Foo {
+    void fooMethod() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/wildcardimport3/input/com/example/Simple.java
+++ b/src/test/resources/wildcardimport3/input/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+// The input has Foo in the second of these packages,
+// so we should put it there.
+import org.example.*;
+import org.anotherexample.*;
+
+class Simple {
+    // Target method.
+    void bar() {
+        Foo obj = new Foo();
+        obj.fooMethod();
+    }
+}

--- a/src/test/resources/wildcardimport3/input/org/anotherexample/Foo.java
+++ b/src/test/resources/wildcardimport3/input/org/anotherexample/Foo.java
@@ -1,6 +1,5 @@
 package org.anotherexample;
 
-// wildcard import rules should find this class, because it is in the input
 public class Foo {
     void fooMethod() { }
 }

--- a/src/test/resources/wildcardimport3/input/org/anotherexample/Foo.java
+++ b/src/test/resources/wildcardimport3/input/org/anotherexample/Foo.java
@@ -1,5 +1,5 @@
 package org.anotherexample;
 
 public class Foo {
-    void fooMethod() { }
+    public void fooMethod() { }
 }

--- a/src/test/resources/wildcardimport3/input/org/anotherexample/Foo.java
+++ b/src/test/resources/wildcardimport3/input/org/anotherexample/Foo.java
@@ -1,0 +1,6 @@
+package org.anotherexample;
+
+// wildcard import rules should find this class, because it is in the input
+public class Foo {
+    void fooMethod() { }
+}

--- a/src/test/resources/wildcardimport4/expected/com/example/Foo.java
+++ b/src/test/resources/wildcardimport4/expected/com/example/Foo.java
@@ -1,4 +1,4 @@
-package org.anotherexample;
+package com.example;
 
 public class Foo {
     void fooMethod() {

--- a/src/test/resources/wildcardimport4/expected/com/example/Foo.java
+++ b/src/test/resources/wildcardimport4/expected/com/example/Foo.java
@@ -1,0 +1,7 @@
+package org.anotherexample;
+
+public class Foo {
+    void fooMethod() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/wildcardimport4/expected/com/example/Simple.java
+++ b/src/test/resources/wildcardimport4/expected/com/example/Simple.java
@@ -1,7 +1,5 @@
 package com.example;
 
-import org.example.Foo;
-
 class Simple {
     void bar() {
         Foo obj = new Foo();

--- a/src/test/resources/wildcardimport4/expected/com/example/Simple.java
+++ b/src/test/resources/wildcardimport4/expected/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.example.Foo;
+
+class Simple {
+    void bar() {
+        Foo obj = new Foo();
+        obj.fooMethod();
+    }
+}

--- a/src/test/resources/wildcardimport4/input/com/example/Foo.java
+++ b/src/test/resources/wildcardimport4/input/com/example/Foo.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public class Foo {
+    void fooMethod() { }
+}

--- a/src/test/resources/wildcardimport4/input/com/example/Simple.java
+++ b/src/test/resources/wildcardimport4/input/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+// These wildcard imports shouldn't prevent us from finding the Foo
+// in this package.
+import org.example.*;
+import org.anotherexample.*;
+
+class Simple {
+    // Target method.
+    void bar() {
+        Foo obj = new Foo();
+        obj.fooMethod();
+    }
+}


### PR DESCRIPTION
It is likely that this feature is under-tested, so I strongly suggest trying to come up with ways to break it :)