### PR TITLE
Update README to ignore receiver parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To run the tool, use `./gradlew run --args='[OPTIONS]'`.
 The available options are (required options in **bold**, repeatable options in *italics*):
 * **--root**: specifies the root directory of the target project.
 * ***--targetFile***: a source file in which to search for target methods
-* ***--targetMethod***: a target method that must be preserved, and whose dependencies should be stubbed out. Use the format `class.fully.qualified.Name#methodName(Param1Type, Param2Type, ...)`. Note: If a target method has a receiver parameter, i.e., (.. this), exclude that parameter from the signature. Check this [documentation](https://example.com) for more info.
+* ***--targetMethod***: a target method that must be preserved, and whose dependencies should be stubbed out. Use the format `class.fully.qualified.Name#methodName(Param1Type, Param2Type, ...)`. Note: If a target method has a receiver parameter, i.e., (.. this), exclude that parameter from the signature. Check this [documentation](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-ReceiverParameter) for more info.
 
 * **--outputDirectory**: the directory in which to place the output. The directory must be writeable and will be created if it does not exist.
 * *--jarPath*: the absolute path of a Jar file for Specimin to take as input.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ To run the tool, use `./gradlew run --args='[OPTIONS]'`.
 The available options are (required options in **bold**, repeatable options in *italics*):
 * **--root**: specifies the root directory of the target project.
 * ***--targetFile***: a source file in which to search for target methods
-* ***--targetMethod***: a target method that must be preserved, and whose dependencies should be stubbed out. Use the format `class.fully.qualified.Name#methodName(Param1Type, Param2Type, ...)`
+* ***--targetMethod***: a target method that must be preserved, and whose dependencies should be stubbed out. Use the format `class.fully.qualified.Name#methodName(Param1Type, Param2Type, ...). Note: If a target method has a receiver parameter, i.e., (.. this), exclude that parameter from the signature. Check this [documentation](https://example.com) for more info.
+
 * **--outputDirectory**: the directory in which to place the output. The directory must be writeable and will be created if it does not exist.
 * *--jarPath*: the absolute path of a Jar file for Specimin to take as input.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To run the tool, use `./gradlew run --args='[OPTIONS]'`.
 The available options are (required options in **bold**, repeatable options in *italics*):
 * **--root**: specifies the root directory of the target project.
 * ***--targetFile***: a source file in which to search for target methods
-* ***--targetMethod***: a target method that must be preserved, and whose dependencies should be stubbed out. Use the format `class.fully.qualified.Name#methodName(Param1Type, Param2Type, ...). Note: If a target method has a receiver parameter, i.e., (.. this), exclude that parameter from the signature. Check this [documentation](https://example.com) for more info.
+* ***--targetMethod***: a target method that must be preserved, and whose dependencies should be stubbed out. Use the format `class.fully.qualified.Name#methodName(Param1Type, Param2Type, ...)`. Note: If a target method has a receiver parameter, i.e., (.. this), exclude that parameter from the signature. Check this [documentation](https://example.com) for more info.
 
 * **--outputDirectory**: the directory in which to place the output. The directory must be writeable and will be created if it does not exist.
 * *--jarPath*: the absolute path of a Jar file for Specimin to take as input.


### PR DESCRIPTION
Professor,

This PR updates the README so that users don't add receiver parameters to signatures of target methods. Please take a look. Thank you.

Note: the CI is failing because we need to update the result of cf-3020.