### PR TITLE
Check for type var before resolving in declaredInCurrentClass

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -181,7 +181,8 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   private Map<String, @ClassGetSimpleName String> fieldNameToClassNameMap = new HashMap<>();
 
   /**
-   * The fully-qualified name of each Java class in the original codebase mapped to the corresponding Java file.
+   * The fully-qualified name of each Java class in the original codebase mapped to the
+   * corresponding Java file.
    */
   private Map<String, Path> existingClassesToFilePath;
 
@@ -232,7 +233,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    * Create a new UnsolvedSymbolVisitor instance
    *
    * @param rootDirectory the root directory of the input files
-   * @param existingClassesToFilePath The fully-qualified name of each Java class in the original 
+   * @param existingClassesToFilePath The fully-qualified name of each Java class in the original
    *     codebase mapped to the corresponding Java file.
    * @param targetMethodsSignatures the list of signatures of target methods as specified by the
    *     user.
@@ -1082,12 +1083,16 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         List<String> methodDeclaredTypesOfParameters = new ArrayList<>();
         for (Parameter parameter : methodDeclaredParameters) {
           try {
-            ResolvedType parameterTypeResolved = parameter.getType().resolve();
-            if (parameterTypeResolved.isPrimitive()) {
-              methodDeclaredTypesOfParameters.add(parameterTypeResolved.asPrimitive().name());
-            } else if (parameterTypeResolved.isReferenceType()) {
-              methodDeclaredTypesOfParameters.add(
-                  parameterTypeResolved.asReferenceType().getQualifiedName());
+            if (isTypeVar(parameter.getTypeAsString())) {
+              methodDeclaredTypesOfParameters.add(parameter.getTypeAsString());
+            } else {
+              ResolvedType parameterTypeResolved = parameter.getType().resolve();
+              if (parameterTypeResolved.isPrimitive()) {
+                methodDeclaredTypesOfParameters.add(parameterTypeResolved.asPrimitive().name());
+              } else if (parameterTypeResolved.isReferenceType()) {
+                methodDeclaredTypesOfParameters.add(
+                    parameterTypeResolved.asReferenceType().getQualifiedName());
+              }
             }
           } catch (UnsolvedSymbolException e) {
             // UnsolvedSymbolVisitor will not create any synthetic class at this iteration.

--- a/src/main/resources/target_status.json
+++ b/src/main/resources/target_status.json
@@ -11,10 +11,10 @@
   "cf-577": "PASS",
   "cf-3032": "FAIL",
   "cf-3619": "PASS",
-  "cf-3021": "FAIL",
+  "cf-3021": "PASS",
   "cf-3020": "PASS",
   "cf-3022": "PASS",
   "cf-691": "PASS",
   "Issue689": "FAIL",
-  "cf-6388": "FAIL"
+  "cf-6388": "PASS"
 }

--- a/src/test/java/org/checkerframework/specimin/TypeVarParameterTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarParameterTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks if Specimin can handle a method call with a parameter of generic type, such as
+ * foo(T input).
+ */
+public class TypeVarParameterTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarparameter",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/typevarparameter/expected/com/example/Simple.java
+++ b/src/test/resources/typevarparameter/expected/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+public class Simple<T> {
+
+    T field;
+
+    void foo(T input) {
+        throw new Error();
+    }
+
+    void bar() {
+        foo(field);
+    }
+}

--- a/src/test/resources/typevarparameter/input/com/example/Simple.java
+++ b/src/test/resources/typevarparameter/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+public class Simple<T> {
+
+    T field;
+    void foo(T input) {
+        System.out.println("This method will be emptied!");
+    }
+
+    void bar() {
+        foo(field);
+    }
+}


### PR DESCRIPTION
Professor,

This PR fixes cf-3021 issue. It adds a simple check for type variables before trying to resolve types. Please take a look. Thank you.