### PR TITLE
Ignore annotations in target method signatures

### DIFF
--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * The main visitor for Specimin's first phase, which locates the target method(s) and compiles
@@ -110,7 +111,9 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
    */
   public TargetMethodFinderVisitor(List<String> methodNames) {
     targetMethodNames = new HashSet<>();
-    targetMethodNames.addAll(methodNames);
+    for (String methodSignature : methodNames) {
+      this.targetMethodNames.add(methodSignature.replaceAll("\\s", ""));
+    }
     unfoundMethods = new ArrayList<>(methodNames);
     importedClassToPackage = new HashMap<>();
   }
@@ -243,7 +246,8 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   public Visitable visit(MethodDeclaration method, Void p) {
     String methodDeclAsString = method.getDeclarationAsString(false, false, false);
     // TODO: test this with annotations
-    String methodName = this.classFQName + "#" + removeMethodReturnType(methodDeclAsString);
+    String methodName =
+        this.classFQName + "#" + removeMethodReturnTypeAndAnnotations(methodDeclAsString);
     // this method belongs to an anonymous class inside the target method
     if (insideTargetMethod) {
       ObjectCreationExpr parentExpression = (ObjectCreationExpr) method.getParentNode().get();
@@ -253,8 +257,7 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
       usedMembers.add(methodPackage + "." + methodClass + "." + method.getNameAsString() + "()");
       updateUsedClassWithQualifiedClassName(methodPackage + "." + methodClass);
     }
-
-    if (this.targetMethodNames.contains(methodName)) {
+    if (this.targetMethodNames.contains(methodName.replaceAll("\\s", ""))) {
       ResolvedMethodDeclaration resolvedMethod = method.resolve();
       updateUsedClassesForInterface(resolvedMethod);
       updateUsedClassWithQualifiedClassName(
@@ -363,8 +366,7 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
     if (insideTargetMethod) {
       ResolvedMethodDeclaration decl = call.resolve();
       usedMembers.add(decl.getQualifiedSignature());
-      updateUsedClassWithQualifiedClassName(
-          decl.getPackageName() + "." + decl.getClassName());
+      updateUsedClassWithQualifiedClassName(decl.getPackageName() + "." + decl.getClassName());
       ResolvedType methodReturnType = decl.getReturnType();
       if (methodReturnType instanceof ResolvedReferenceType) {
         updateUsedClassBasedOnType(methodReturnType);
@@ -490,18 +492,22 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
 
   /**
    * Given a method declaration, this method return the declaration of that method without the
-   * return type.
+   * return type and any possible annotation.
    *
    * @param methodDeclaration the method declaration to be used as input
-   * @return methodDeclaration without the return type
+   * @return methodDeclaration without the return type and any possible annotation.
    */
-  public static String removeMethodReturnType(String methodDeclaration) {
+  public static String removeMethodReturnTypeAndAnnotations(String methodDeclaration) {
     String methodDeclarationWithoutParen =
         methodDeclaration.substring(0, methodDeclaration.indexOf("("));
     List<String> methodParts = Splitter.onPattern(" ").splitToList(methodDeclarationWithoutParen);
     String methodName = methodParts.get(methodParts.size() - 1);
     String methodReturnType = methodDeclaration.substring(0, methodDeclaration.indexOf(methodName));
-    return methodDeclaration.replace(methodReturnType, "");
+    String methodWithoutReturnType = methodDeclaration.replace(methodReturnType, "");
+    methodParts = Splitter.onPattern(" ").splitToList(methodWithoutReturnType);
+    String filteredMethodDeclaration =
+        methodParts.stream().filter(part -> !part.startsWith("@")).collect(Collectors.joining(" "));
+    return filteredMethodDeclaration;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -258,14 +258,22 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
       usedMembers.add(methodPackage + "." + methodClass + "." + method.getNameAsString() + "()");
       updateUsedClassWithQualifiedClassName(methodPackage + "." + methodClass);
     }
-    if (this.targetMethodNames.contains(methodName.replaceAll("\\s", ""))) {
+    String methodWithoutAnySpace = methodName.replaceAll("\\s", "");
+    if (this.targetMethodNames.contains(methodWithoutAnySpace)) {
       ResolvedMethodDeclaration resolvedMethod = method.resolve();
       updateUsedClassesForInterface(resolvedMethod);
       updateUsedClassWithQualifiedClassName(
           resolvedMethod.getPackageName() + "." + resolvedMethod.getClassName());
       insideTargetMethod = true;
       targetMethods.add(resolvedMethod.getQualifiedSignature());
-      unfoundMethods.remove(methodName);
+      // String methodToRemove = methodName;
+      // make sure that differences in spacing does not interfere with the result
+      for (String unfound : unfoundMethods) {
+        if (unfound.replaceAll("\\s", "").equals(methodWithoutAnySpace)) {
+          unfoundMethods.remove(unfound);
+          break;
+        }
+      }
       Type returnType = method.getType();
       // JavaParser may misinterpret unresolved array types as reference types.
       // To ensure accuracy, we resolve the type before proceeding with the check.

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -266,7 +266,6 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
           resolvedMethod.getPackageName() + "." + resolvedMethod.getClassName());
       insideTargetMethod = true;
       targetMethods.add(resolvedMethod.getQualifiedSignature());
-      // String methodToRemove = methodName;
       // make sure that differences in spacing does not interfere with the result
       for (String unfound : unfoundMethods) {
         if (unfound.replaceAll("\\s", "").equals(methodWithoutAnySpace)) {

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -48,7 +48,8 @@ import java.util.stream.Collectors;
 public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   /**
    * The names of the target methods. The format is
-   * class.fully.qualified.Name#methodName(Param1Type, Param2Type, ...)
+   * class.fully.qualified.Name#methodName(Param1Type, Param2Type, ...). All the names will have
+   * spaces remove for ease of comparison.
    */
   private Set<String> targetMethodNames;
 

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -202,7 +202,10 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   private final Map<@ClassGetSimpleName String, List<@ClassGetSimpleName String>>
       classToItsUnsolvedInterface = new HashMap<>();
 
-  /** List of signatures of target methods as specified by users. */
+  /**
+   * List of signatures of target methods as specified by users. All signatures have spaces removed
+   * for ease of comparison.
+   */
   private final Set<String> targetMethodsSignatures;
 
   /**

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -181,7 +181,8 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   private Map<String, @ClassGetSimpleName String> fieldNameToClassNameMap = new HashMap<>();
 
   /**
-   * The fully-qualified name of each Java class in the original codebase mapped to the corresponding Java file.
+   * The fully-qualified name of each Java class in the original codebase mapped to the
+   * corresponding Java file.
    */
   private Map<String, Path> existingClassesToFilePath;
 
@@ -232,7 +233,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    * Create a new UnsolvedSymbolVisitor instance
    *
    * @param rootDirectory the root directory of the input files
-   * @param existingClassesToFilePath The fully-qualified name of each Java class in the original 
+   * @param existingClassesToFilePath The fully-qualified name of each Java class in the original
    *     codebase mapped to the corresponding Java file.
    * @param targetMethodsSignatures the list of signatures of target methods as specified by the
    *     user.
@@ -245,7 +246,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     this.gotException = true;
     this.existingClassesToFilePath = existingClassesToFilePath;
     this.targetMethodsSignatures = new HashSet<>();
-    this.targetMethodsSignatures.addAll(targetMethodsSignatures);
+    for (String methodSignature : targetMethodsSignatures) {
+      this.targetMethodsSignatures.add(methodSignature.replaceAll("\\s", ""));
+    }
   }
 
   /**
@@ -750,9 +753,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     String methodQualifiedSignature =
         this.currentClassQualifiedName
             + "#"
-            + TargetMethodFinderVisitor.removeMethodReturnType(
+            + TargetMethodFinderVisitor.removeMethodReturnTypeAndAnnotations(
                 node.getDeclarationAsString(false, false, false));
-    if (targetMethodsSignatures.contains(methodQualifiedSignature)) {
+    if (targetMethodsSignatures.contains(methodQualifiedSignature.replace("\\s", ""))) {
       insideTargetMethod = true;
     }
     addTypeVariableScope(node.getTypeParameters());
@@ -769,10 +772,10 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     String methodQualifiedSignature =
         this.currentClassQualifiedName
             + "#"
-            + TargetMethodFinderVisitor.removeMethodReturnType(
+            + TargetMethodFinderVisitor.removeMethodReturnTypeAndAnnotations(
                 node.getDeclarationAsString(false, false, false));
     String methodSimpleName = node.getName().asString();
-    if (targetMethodsSignatures.contains(methodQualifiedSignature)) {
+    if (targetMethodsSignatures.contains(methodQualifiedSignature.replaceAll("\\s", ""))) {
       insideTargetMethod = true;
       Visitable result = processMethodDeclaration(node);
       insideTargetMethod = false;

--- a/src/main/resources/target_status.json
+++ b/src/main/resources/target_status.json
@@ -5,7 +5,7 @@
   "cf-6060": "PASS",
   "cf-6030": "PASS",
   "cf-6030b": "FAIL",
-  "cf-6019": "FAIL",
+  "cf-6019": "PASS",
   "cf-4614": "PASS",
   "cf-3850": "FAIL",
   "cf-577": "PASS",
@@ -16,5 +16,5 @@
   "cf-3022": "PASS",
   "cf-691": "PASS",
   "Issue689": "FAIL",
-  "cf-6388": "FAIL"
+  "cf-6388": "PASS"
 }

--- a/src/test/java/org/checkerframework/specimin/ParameterWithAnnotationsTest.java
+++ b/src/test/java/org/checkerframework/specimin/ParameterWithAnnotationsTest.java
@@ -13,7 +13,7 @@ public class ParameterWithAnnotationsTest {
     SpeciminTestExecutor.runTest(
         "parameterwithannotations",
         new String[] {"com/example/Simple.java"},
-        new String[] {"com.example.Simple#bar(int, UnsolvedType)"},
+        new String[] {"com.example.Simple#bar(byte[], UnsolvedType)"},
         new String[] {"src/test/resources/shared/checker-qual-3.42.0.jar"});
   }
 }

--- a/src/test/java/org/checkerframework/specimin/ParameterWithAnnotationsTest.java
+++ b/src/test/java/org/checkerframework/specimin/ParameterWithAnnotationsTest.java
@@ -10,9 +10,10 @@ import org.junit.Test;
 public class ParameterWithAnnotationsTest {
   @Test
   public void runTest() throws IOException {
-    SpeciminTestExecutor.runTestWithoutJarPaths(
+    SpeciminTestExecutor.runTest(
         "parameterwithannotations",
         new String[] {"com/example/Simple.java"},
-        new String[] {"com.example.Simple#bar(int, UnsolvedType)"});
+        new String[] {"com.example.Simple#bar(int, UnsolvedType)"},
+        new String[] {"src/test/resources/shared/checker-qual-3.42.0.jar"});
   }
 }

--- a/src/test/java/org/checkerframework/specimin/ParameterWithAnnotationsTest.java
+++ b/src/test/java/org/checkerframework/specimin/ParameterWithAnnotationsTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that Specimin can properly ignore annotations in the parameters of a target
+ * method while comparing method signatures.
+ */
+public class ParameterWithAnnotationsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "parameterwithannotations",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(int, UnsolvedType)"});
+  }
+}

--- a/src/test/resources/parameterwithannotations/expected/com/example/Simple.java
+++ b/src/test/resources/parameterwithannotations/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.testing.UnsolvedType;
+
+class Simple {
+
+    void bar(int first, @Nullable UnsolvedType second) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/parameterwithannotations/expected/com/example/Simple.java
+++ b/src/test/resources/parameterwithannotations/expected/com/example/Simple.java
@@ -5,7 +5,7 @@ import org.testing.UnsolvedType;
 
 class Simple {
 
-    void bar(int first, @Nullable UnsolvedType second) {
+    void bar(byte @Nullable [] first, @Nullable UnsolvedType second) {
         throw new Error();
     }
 }

--- a/src/test/resources/parameterwithannotations/expected/org/testing/UnsolvedType.java
+++ b/src/test/resources/parameterwithannotations/expected/org/testing/UnsolvedType.java
@@ -1,0 +1,4 @@
+package org.testing;
+
+public class UnsolvedType {
+}

--- a/src/test/resources/parameterwithannotations/input/com/example/Simple.java
+++ b/src/test/resources/parameterwithannotations/input/com/example/Simple.java
@@ -4,7 +4,7 @@ import  org.checkerframework.checker.nullness.qual.Nullable;
 import org.testing.UnsolvedType;
 
 class Simple {
-    void bar(int first, @Nullable UnsolvedType second) {
+    void bar(byte @Nullable [] first, @Nullable UnsolvedType second) {
         throw new Error();
     }
 

--- a/src/test/resources/parameterwithannotations/input/com/example/Simple.java
+++ b/src/test/resources/parameterwithannotations/input/com/example/Simple.java
@@ -1,0 +1,15 @@
+package com.example;
+
+import  org.checkerframework.checker.nullness.qual.Nullable;
+import org.testing.UnsolvedType;
+
+class Simple {
+    void bar(int first, @Nullable UnsolvedType second) {
+        throw new Error();
+    }
+
+    void foo() {
+        System.out.println("This method will be removed!");
+    }
+}
+

--- a/src/test/resources/parameterwithannotations/input/org/testing/UnsolvedType.java
+++ b/src/test/resources/parameterwithannotations/input/org/testing/UnsolvedType.java
@@ -1,3 +1,0 @@
-package org.testing;
-public class UnsolvedType {
-}

--- a/src/test/resources/parameterwithannotations/input/org/testing/UnsolvedType.java
+++ b/src/test/resources/parameterwithannotations/input/org/testing/UnsolvedType.java
@@ -1,0 +1,3 @@
+package org.testing;
+public class UnsolvedType {
+}


### PR DESCRIPTION
This PR ignores annotations in target method signatures. Due to the difficulty in keeping space consistency after removing annotations, such as the transformation of `byte @Nullable []` to `byte[]` (removing both starting and ending spaces), versus `int x, @Nullable int b`, which becomes `int x, int b` (only removing the ending space), this PR removes all spaces from target method signatures prior to comparison.

Please take a look. Thank you.
