### PR TITLE
Preserve arguments to enum constructors called in enum constants

### DIFF
--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -260,12 +260,16 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
         this.classFQName + "#" + removeMethodReturnTypeAndAnnotations(methodDeclAsString);
     // this method belongs to an anonymous class inside the target method
     if (insideTargetMethod) {
-      ObjectCreationExpr parentExpression = (ObjectCreationExpr) method.getParentNode().get();
-      ResolvedConstructorDeclaration resolved = parentExpression.resolve();
-      String methodPackage = resolved.getPackageName();
-      String methodClass = resolved.getClassName();
-      usedMembers.add(methodPackage + "." + methodClass + "." + method.getNameAsString() + "()");
-      updateUsedClassWithQualifiedClassName(methodPackage + "." + methodClass);
+      Node parentNode = method.getParentNode().get();
+      // it could also be an enum declaration, but those are handled separately
+      if (parentNode instanceof ObjectCreationExpr) {
+        ObjectCreationExpr parentExpression = (ObjectCreationExpr) parentNode;
+        ResolvedConstructorDeclaration resolved = parentExpression.resolve();
+        String methodPackage = resolved.getPackageName();
+        String methodClass = resolved.getClassName();
+        usedMembers.add(methodPackage + "." + methodClass + "." + method.getNameAsString() + "()");
+        updateUsedClassWithQualifiedClassName(methodPackage + "." + methodClass);
+      }
     }
     String methodWithoutAnySpace = methodName.replaceAll("\\s", "");
     if (this.targetMethodNames.contains(methodWithoutAnySpace)) {
@@ -437,7 +441,6 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
         // if the a field is accessed in the form of a fully-qualified path, such as
         // org.example.A.b, then other components in the path apart from the class name and field
         // name, such as org and org.example, will also be considered as FieldAccessExpr.
-        System.out.println(e);
       }
     }
     Expression caller = expr.getScope();

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -930,6 +930,18 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
   }
 
   @Override
+  public Visitable visit(EnumConstantDeclaration expr, Void p) {
+    // this is a bit hacky, but we don't remove any enum constant declarations if they
+    // are ever used, so it's safer to just preserve anything that they use by pretending
+    // that we're inside a target method.
+    boolean oldInsideTargetMethod = insideTargetMethod;
+    insideTargetMethod = true;
+    Visitable result = super.visit(expr, p);
+    insideTargetMethod = oldInsideTargetMethod;
+    return result;
+  }
+
+  @Override
   public Visitable visit(ClassOrInterfaceType typeExpr, Void p) {
     // Workaround for a JavaParser bug: When a type is referenced using its fully-qualified name,
     // like

--- a/src/test/java/org/checkerframework/specimin/EnumConstantArgTest.java
+++ b/src/test/java/org/checkerframework/specimin/EnumConstantArgTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks if Specimin correctly preserves things that are used as arguments to enum
+ * constants.
+ */
+public class EnumConstantArgTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "enumconstantarg",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#bar()"});
+  }
+}

--- a/src/test/resources/enumconstantarg/expected/com/example/Foo.java
+++ b/src/test/resources/enumconstantarg/expected/com/example/Foo.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import org.example.Op;
+
+class Foo {
+
+    public enum Mode {
+
+        PREFIX(Op.EQ), CONTAINS(Op.CONTAINS), SPARSE(Op.NOT_EQ);
+
+        Op op;
+
+        Mode(Op op) {
+            this.op = op;
+        }
+    }
+
+    public void bar() {
+        Mode mode = Mode.PREFIX;
+    }
+}

--- a/src/test/resources/enumconstantarg/expected/com/example/Foo.java
+++ b/src/test/resources/enumconstantarg/expected/com/example/Foo.java
@@ -8,10 +8,8 @@ class Foo {
 
         PREFIX(Op.EQ), CONTAINS(Op.CONTAINS), SPARSE(Op.NOT_EQ);
 
-        Op op;
-
         Mode(Op op) {
-            this.op = op;
+            throw new Error();
         }
     }
 

--- a/src/test/resources/enumconstantarg/expected/org/example/Op.java
+++ b/src/test/resources/enumconstantarg/expected/org/example/Op.java
@@ -2,9 +2,9 @@ package org.example;
 
 public class Op {
 
-    public static final Op EQ = null;
+    public static org.example.Op CONTAINS;
 
-    public static final Op CONTAINS = null;
+    public static org.example.Op EQ;
 
-    public static final Op NOT_EQ = null;
+    public static org.example.Op NOT_EQ;
 }

--- a/src/test/resources/enumconstantarg/expected/org/example/Op.java
+++ b/src/test/resources/enumconstantarg/expected/org/example/Op.java
@@ -1,0 +1,10 @@
+package org.example;
+
+public class Op {
+
+    public static final Op EQ = null;
+
+    public static final Op CONTAINS = null;
+
+    public static final Op NOT_EQ = null;
+}

--- a/src/test/resources/enumconstantarg/input/com/example/Foo.java
+++ b/src/test/resources/enumconstantarg/input/com/example/Foo.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import org.example.Op;
+
+class Foo {
+
+    public enum Mode {
+
+        PREFIX(Op.EQ), CONTAINS(Op.CONTAINS), SPARSE(Op.NOT_EQ);
+
+        Op op;
+
+        Mode(Op op) {
+            this.op = op;
+        }
+    }
+
+    public void bar() {
+        Mode mode = Mode.PREFIX;
+    }
+}


### PR DESCRIPTION
This fixes one of the compilation bugs in CF-6077 (i.e., the integration test target derived from Apache Cassandra); there are others (including, I think, the one that #191 is intended to solve). This PR only handles enum constants; I don't expect CF-6077 to compile with just this PR.

We already are very approximate with enum constants (see #81 for example), so this change just acknowledges that. The implementation is a bit hacky, but it's cleaner than trying to add another boolean that we'd need to check in each other visit method.