### PR TITLE
Preserve overrides that are required for compilability

### DIFF
--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -252,6 +252,10 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
   /**
    * Given a MethodDeclaration, this method returns the method that it overrides, if one exists in
    * one of its super classes. If one does not exist, it returns null.
+   *
+   * @param methodDeclaration the method declaration to check
+   * @return the method that this method overrides, if one exists in a superclass. Null if no such
+   *     method exists.
    */
   public static @Nullable ResolvedMethodDeclaration getOverriddenMethodInSuperClass(
       MethodDeclaration methodDeclaration) {

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -147,8 +147,16 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
    * @return true iff the given method definitely overrides a preserved method
    */
   private boolean isOverride(MethodDeclaration method) {
-    ResolvedMethodDeclaration resolved = method.resolve();
-    String signature = resolved.getSignature();
+    ResolvedMethodDeclaration resolved;
+    String signature;
+    try {
+      resolved = method.resolve();
+      signature = resolved.getSignature();
+    } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
+      // Some part of the signature isn't being preserved, so this shouldn't be preserved,
+      // either.
+      return false;
+    }
     Node typeElt = PrunerVisitor.getEnclosingClassLike(method);
 
     // Whether or not to fall back on the presence of an @Override annotation. We want

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -1,0 +1,150 @@
+package org.checkerframework.specimin;
+
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.SuperExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.visitor.ModifierVisitor;
+import com.github.javaparser.ast.visitor.Visitable;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedParameterDeclaration;
+import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * If a used class includes methods that must be implemented (because it extends an abstract class
+ * or implements an interface that requires them), this visitor marks them for preservation. Should
+ * run after the list of used classes is finalized.
+ */
+public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
+
+  /** Set containing the signatures of used member (fields and methods). */
+  private Set<String> usedMembers;
+
+  /** Set containing the signatures of used classes. */
+  private Set<String> usedClass;
+
+  /**
+   * Constructs a new SolveMethodOverridingVisitor with the provided sets of target methods, used
+   * members, and used classes.
+   *
+   * @param usedMembers Set containing the signatures of used members.
+   * @param usedClass Set containing the signatures of used classes.
+   */
+  public MustImplementMethodsVisitor(Set<String> usedMembers, Set<String> usedClass) {
+    this.usedMembers = usedMembers;
+    this.usedClass = usedClass;
+  }
+
+  /**
+   * Get the set containing the signatures of used members.
+   *
+   * @return The set containing the signatures of used members.
+   */
+  public Set<String> getUsedMembers() {
+    return usedMembers;
+  }
+
+  /**
+   * Get the set containing the signatures of used classes.
+   *
+   * @return The set containing the signatures of used classes.
+   */
+  public Set<String> getUsedClass() {
+    return usedClass;
+  }
+
+  @Override
+  public Visitable visit(ClassOrInterfaceDeclaration type, Void p) {
+    if (type.getFullyQualifiedName().isPresent()
+        && usedClass.contains(type.getFullyQualifiedName().get())) {
+      return super.visit(type, p);
+    } else {
+      // the effect of not calling super here is that only used classes
+      // will actually be visited by this class
+      return null;
+    }
+  }
+
+  @Override
+  public Visitable visit(MethodDeclaration method, Void p) {
+    ResolvedMethodDeclaration overridden = getOverriddenMethod(method);
+    // two cases: the method is a solvable override, and we can show that
+    // it is abstract (before the ||), or we can't solve the override but there
+    // is an @Override annotation. This relies on the use of @Override when
+    // implementing required methods from interfaces in the target code,
+    // but unfortunately I think it's the best that we can do here. (@Override
+    // is technically optional, but it is widely used.)
+    if (isAbstract(overridden) || (overridden == null && isOverride(method))) {
+      ResolvedMethodDeclaration resolvedMethod = method.resolve();
+      usedMembers.add(resolvedMethod.getQualifiedSignature());
+      usedClass.add(resolvedMethod.getReturnType().describe());
+      for (int i = 0; i < resolvedMethod.getNumberOfParams(); ++i) {
+        ResolvedParameterDeclaration param = resolvedMethod.getParam(i);
+        usedClass.add(param.describeType());
+      }
+    }
+    return super.visit(method, p);
+  }
+
+  /**
+   * Returns true if the given method is abstract.
+   *
+   * @param method a possibly-null method declaration
+   * @return true iff the input is non-null and abstract
+   */
+  private boolean isAbstract(@Nullable ResolvedMethodDeclaration method) {
+    return method != null && method.isAbstract();
+  }
+
+  /**
+   * Returns true iff the given method declaration has an @Override annotation. This is a coarse
+   * approximation (@Override is optional, unfortunately), but it's the best we can do given the
+   * limits of JavaParser.
+   *
+   * @param method the method declaration to check
+   * @return true iff there is an override annotation on the given method
+   */
+  private boolean isOverride(MethodDeclaration method) {
+    return method.getAnnotationByName("Override").isPresent()
+        || method.getAnnotationByName("java.lang.Override").isPresent();
+  }
+
+  /**
+   * Given a MethodDeclaration, this method returns the method that it overrides, if one exists. If
+   * not, it returns null.
+   */
+  private @Nullable ResolvedMethodDeclaration getOverriddenMethod(
+      MethodDeclaration methodDeclaration) {
+    // just a method signature, no need to check for overriding.
+    if (methodDeclaration.getBody().isEmpty()) {
+      return null;
+    }
+    BlockStmt methodBody = methodDeclaration.getBody().get();
+    // JavaParser does not support solving overriding, but it does support solving super
+    // expressions. So we make a temporary super expression to figure out if this current method is
+    // overriding.
+    MethodCallExpr superCall = new MethodCallExpr();
+    superCall.setName(methodDeclaration.getName());
+    NodeList<Parameter> parameters = methodDeclaration.getParameters();
+    for (Parameter parameter : parameters) {
+      superCall.addArgument(parameter.getNameAsString());
+    }
+    superCall.setScope(new SuperExpr());
+    methodBody.addStatement(superCall);
+    ResolvedMethodDeclaration resolvedSuperCall = null;
+    try {
+      resolvedSuperCall = superCall.resolve();
+    } catch (Exception e) {
+      // The current method is not overriding, thus the super call is unresolved.
+      // This catch block is necessary to avoid crashes due to ignored catch blocks. A single
+      // remove() call is not enough to remove a MethodCallExpr.
+      superCall.remove();
+    }
+    JavaParserUtil.removeNode(superCall);
+    return resolvedSuperCall;
+  }
+}

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -58,6 +58,7 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
   }
 
   @Override
+  @SuppressWarnings("nullness:return") // ok to return null, because this is a void visitor
   public Visitable visit(ClassOrInterfaceDeclaration type, Void p) {
     if (type.getFullyQualifiedName().isPresent()
         && usedClass.contains(type.getFullyQualifiedName().get())) {

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -82,7 +82,6 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
     // but unfortunately I think it's the best that we can do here. (@Override
     // is technically optional, but it is widely used.)
     if (isPreservedAndAbstract(overridden) || (overridden == null && isOverride(method))) {
-      System.out.println("overridden: " + overridden.getQualifiedSignature());
       ResolvedMethodDeclaration resolvedMethod = method.resolve();
       Set<String> returnAndParamTypes = new HashSet<>();
       try {

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -75,13 +75,14 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
   @Override
   public Visitable visit(MethodDeclaration method, Void p) {
     ResolvedMethodDeclaration overridden = getOverriddenMethod(method);
-    // two cases: the method is a solvable override, and we can show that
+    // two cases: the method is a solvable override that will be preserved, and we can show that
     // it is abstract (before the ||), or we can't solve the override but there
     // is an @Override annotation. This relies on the use of @Override when
     // implementing required methods from interfaces in the target code,
     // but unfortunately I think it's the best that we can do here. (@Override
     // is technically optional, but it is widely used.)
-    if (isAbstract(overridden) || (overridden == null && isOverride(method))) {
+    if (isPreservedAndAbstract(overridden) || (overridden == null && isOverride(method))) {
+      System.out.println("overridden: " + overridden.getQualifiedSignature());
       ResolvedMethodDeclaration resolvedMethod = method.resolve();
       Set<String> returnAndParamTypes = new HashSet<>();
       try {
@@ -120,8 +121,10 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
    * @param method a possibly-null method declaration
    * @return true iff the input is non-null and abstract
    */
-  private boolean isAbstract(@Nullable ResolvedMethodDeclaration method) {
-    return method != null && method.isAbstract();
+  private boolean isPreservedAndAbstract(@Nullable ResolvedMethodDeclaration method) {
+    return method != null
+        && method.isAbstract()
+        && usedMembers.contains(method.getQualifiedSignature());
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -90,7 +90,7 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
           ResolvedParameterDeclaration param = resolvedMethod.getParam(i);
           returnAndParamTypes.add(param.describeType());
         }
-      } catch (UnsolvedSymbolException e) {
+      } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
         // In this case, don't keep the method (it won't compile anyway,
         // since some needed symbol isn't available). TODO: find a way to trigger the
         // creation of a synthetic class for the unsolved symbol at this point.
@@ -98,6 +98,16 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
       }
       usedMembers.add(resolvedMethod.getQualifiedSignature());
       for (String type : returnAndParamTypes) {
+        type = type.trim();
+        if (type.contains("<")) {
+          // remove generics, if present, since this type will be used in
+          // an import
+          type = type.substring(0, type.indexOf("<"));
+        }
+        // also remove array types
+        if (type.contains("[]")) {
+          type = type.replace("[]", "");
+        }
         usedClass.add(type);
       }
     }

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -228,12 +228,10 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
           resolvedInterface.getAllMethodsVisibleToInheritors()) {
         if (methodInInterface.isAbstract()
             && erase(methodInInterface.getSignature()).equals(targetSignature)) {
-          // once we've found the correct method, we return to the question of whether we
+          // once we've found the correct method, we return to whether we
           // control it or not. If we don't, it must be preserved. If we do, then we only
           // preserve it if the PrunerVisitor won't remove it.
-          boolean result =
-              !inOutput || usedMembers.contains(methodInInterface.getQualifiedSignature());
-          return result;
+          return !inOutput || usedMembers.contains(methodInInterface.getQualifiedSignature());
         }
       }
     }

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -118,7 +118,7 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
    * Given a MethodDeclaration, this method returns the method that it overrides, if one exists. If
    * not, it returns null.
    */
-  private @Nullable ResolvedMethodDeclaration getOverriddenMethod(
+  public static @Nullable ResolvedMethodDeclaration getOverriddenMethod(
       MethodDeclaration methodDeclaration) {
     // just a method signature, no need to check for overriding.
     if (methodDeclaration.getBody().isEmpty()) {

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -123,7 +123,14 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
       decl.remove();
       for (String usedClassFQN : classesUsedByTargetMethods) {
         if (usedClassFQN.startsWith(importedPackage)) {
-          parent.addImport(usedClassFQN);
+          try {
+            parent.addImport(usedClassFQN);
+          } catch (com.github.javaparser.ParseProblemException e) {
+            // ParseProblemException is not very helpful for figuring out what the problem is
+            // if we make a bug that causes it to be thrown (it only prints out the part of
+            // the type that is the problem, not the whole type).
+            throw new RuntimeException("failed trying to parse this import: " + usedClassFQN, e);
+          }
         }
       }
       return decl;

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -376,10 +376,7 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
    */
   @SuppressWarnings("signature") // result is a fully-qualified name or else this throws
   public static @FullyQualifiedName String getEnclosingClassName(Node node) {
-    Node parent = node.getParentNode().orElseThrow();
-    while (!(parent instanceof ClassOrInterfaceDeclaration || parent instanceof EnumDeclaration)) {
-      parent = parent.getParentNode().orElseThrow();
-    }
+    Node parent = getEnclosingClassLike(node);
     if (parent instanceof ClassOrInterfaceDeclaration) {
       return ((ClassOrInterfaceDeclaration) parent).getFullyQualifiedName().orElseThrow();
     } else if (parent instanceof EnumDeclaration) {
@@ -387,6 +384,23 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
     } else {
       throw new RuntimeException("unexpected kind of node: " + parent.getClass());
     }
+  }
+
+  /**
+   * Returns the innermost enclosing class-like element for the given node. A class-like element is
+   * a class, interface, or enum (i.e., something that would be a {@link
+   * javax.lang.model.element.TypeElement} in javac's internal model). This method will throw if no
+   * such element exists.
+   *
+   * @param node a node that is contained in a class-like structure
+   * @return the nearest enclosing class-like node
+   */
+  public static Node getEnclosingClassLike(Node node) {
+    Node parent = node.getParentNode().orElseThrow();
+    while (!(parent instanceof ClassOrInterfaceDeclaration || parent instanceof EnumDeclaration)) {
+      parent = parent.getParentNode().orElseThrow();
+    }
+    return parent;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/SolveMethodOverridingVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/SolveMethodOverridingVisitor.java
@@ -76,7 +76,7 @@ public class SolveMethodOverridingVisitor extends ModifierVisitor<Void> {
    */
   private void checkForOverridingAndUpdateUsedClasses(MethodDeclaration methodDeclaration) {
     ResolvedMethodDeclaration resolvedSuperCall =
-        MustImplementMethodsVisitor.getOverriddenMethod(methodDeclaration);
+        MustImplementMethodsVisitor.getOverriddenMethodInSuperClass(methodDeclaration);
     if (resolvedSuperCall != null) {
       usedClass.add(resolvedSuperCall.getPackageName() + "." + resolvedSuperCall.getClassName());
       usedMembers.add(resolvedSuperCall.getQualifiedSignature());

--- a/src/main/java/org/checkerframework/specimin/SolveMethodOverridingVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/SolveMethodOverridingVisitor.java
@@ -71,6 +71,7 @@ public class SolveMethodOverridingVisitor extends ModifierVisitor<Void> {
     if (targetMethod.contains(methodSignature) || usedMembers.contains(methodSignature)) {
       checkForOverridingAndUpdateUsedClasses(method);
     }
+
     return super.visit(method, p);
   }
 

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -305,7 +305,7 @@ public class SpeciminRunner {
 
     MustImplementMethodsVisitor mustImplementMethodsVisitor =
         new MustImplementMethodsVisitor(
-            solveMethodOverridingVisitor.getUsedMembers(), updatedUsedClass);
+            solveMethodOverridingVisitor.getUsedMembers(), updatedUsedClass, addMissingClass);
     for (CompilationUnit cu : parsedTargetFiles.values()) {
       cu.accept(mustImplementMethodsVisitor, null);
     }

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -296,11 +296,19 @@ public class SpeciminRunner {
     }
 
     updatedUsedClass.addAll(annoRemover.getSolvedAnnotationFullName());
+
+    MustImplementMethodsVisitor mustImplementMethodsVisitor =
+        new MustImplementMethodsVisitor(
+            solveMethodOverridingVisitor.getUsedMembers(), updatedUsedClass);
+    for (CompilationUnit cu : parsedTargetFiles.values()) {
+      cu.accept(mustImplementMethodsVisitor, null);
+    }
+
     PrunerVisitor methodPruner =
         new PrunerVisitor(
             finder.getTargetMethods(),
-            solveMethodOverridingVisitor.getUsedMembers(),
-            updatedUsedClass);
+            mustImplementMethodsVisitor.getUsedMembers(),
+            mustImplementMethodsVisitor.getUsedClass());
 
     for (CompilationUnit cu : parsedTargetFiles.values()) {
       cu.accept(methodPruner, null);

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -305,7 +305,9 @@ public class SpeciminRunner {
 
     MustImplementMethodsVisitor mustImplementMethodsVisitor =
         new MustImplementMethodsVisitor(
-            solveMethodOverridingVisitor.getUsedMembers(), updatedUsedClass, addMissingClass);
+            solveMethodOverridingVisitor.getUsedMembers(),
+            updatedUsedClass,
+            existingClassesToFilePath);
     for (CompilationUnit cu : parsedTargetFiles.values()) {
       cu.accept(mustImplementMethodsVisitor, null);
     }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedAnnotationRemoverVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedAnnotationRemoverVisitor.java
@@ -103,7 +103,8 @@ public class UnsolvedAnnotationRemoverVisitor extends ModifierVisitor<Void> {
     if (!UnsolvedSymbolVisitor.isAClassPath(annotationName)) {
       if (!classToFullClassName.containsKey(annotationName)) {
         // An annotation not imported and from the java.lang package is not our concern.
-        if (!JavaLangUtils.isJavaLangName(annotationName)) {
+        // Never preserve @Override, since it causes compile errors but does not fix them.
+        if (!JavaLangUtils.isJavaLangName(annotationName) || "Override".equals(annotationName)) {
           annotation.remove();
         }
         return;

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -739,7 +739,6 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     // not a field of any class, or if it is a field of a class but is explicitly referenced, such
     // as "Math.number," we handle it in other visit methods.
     if (!canBeSolved(node)) {
-      System.out.println("node: " + node);
       Optional<Node> parentNode = node.getParentNode();
       // we take care of MethodCallExpr and FieldAccessExpr cases in other visit methods
       if (parentNode.isEmpty()

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -739,6 +739,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     // not a field of any class, or if it is a field of a class but is explicitly referenced, such
     // as "Math.number," we handle it in other visit methods.
     if (!canBeSolved(node)) {
+      System.out.println("node: " + node);
       Optional<Node> parentNode = node.getParentNode();
       // we take care of MethodCallExpr and FieldAccessExpr cases in other visit methods
       if (parentNode.isEmpty()

--- a/src/test/java/org/checkerframework/specimin/AbstractImplTest.java
+++ b/src/test/java/org/checkerframework/specimin/AbstractImplTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that if a class extends an abstract class or implements an interface, the
+ * methods that need to be implemented still are (to preserve compilability).
+ */
+public class AbstractImplTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "abstractimpl",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AbstractImplTest.java
+++ b/src/test/java/org/checkerframework/specimin/AbstractImplTest.java
@@ -13,6 +13,6 @@ public class AbstractImplTest {
     SpeciminTestExecutor.runTestWithoutJarPaths(
         "abstractimpl",
         new String[] {"com/example/Simple.java"},
-        new String[] {"com.example.Simple#bar()"});
+        new String[] {"com.example.Simple#bar(K, Collection<V>)"});
   }
 }

--- a/src/test/java/org/checkerframework/specimin/AbstractOverride2Test.java
+++ b/src/test/java/org/checkerframework/specimin/AbstractOverride2Test.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test is exactly like {@link AbstractOverrideTest}, but with an interface instead of an
+ * abstract class.
+ */
+public class AbstractOverride2Test {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "abstractoverride2",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/AbstractOverrideTest.java
+++ b/src/test/java/org/checkerframework/specimin/AbstractOverrideTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that if a class extends an abstract class with a method that has to be present,
+ * that method still gets deleted in both the superclass and the subclass if it's not used.
+ */
+public class AbstractOverrideTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "abstractoverride",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/abstractimpl/expected/com/example/Simple.java
+++ b/src/test/resources/abstractimpl/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.Set;
+import java.util.Collection;
+
+import com.example.WrappedSet;
+
+public class Simple<K, V> {
+    // Target method.
+    Collection<V> bar(K key, Collection<V> collection) {
+        return new WrappedSet(key, (Set<V>) collection);
+    }
+}

--- a/src/test/resources/abstractimpl/expected/com/example/Simple.java
+++ b/src/test/resources/abstractimpl/expected/com/example/Simple.java
@@ -6,7 +6,6 @@ import java.util.Collection;
 import com.example.WrappedSet;
 
 public class Simple<K, V> {
-    // Target method.
     Collection<V> bar(K key, Collection<V> collection) {
         return new WrappedSet(key, (Set<V>) collection);
     }

--- a/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
+++ b/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
@@ -10,55 +10,55 @@ class WrappedSet<K, V> implements Set<V> {
         throw new Error();
     }
 
-        public int size() {
+    public int size() {
         throw new Error();
     }
 
-        public Iterator<V> iterator() {
+    public Iterator<V> iterator() {
         throw new Error();
     }
 
-        public void clear() {
+    public void clear() {
         throw new Error();
     }
 
-        public boolean remove(Object o) {
+    public boolean remove(Object o) {
         throw new Error();
     }
 
-        public boolean removeAll(Collection<?> c) {
+    public boolean removeAll(Collection<?> c) {
         throw new Error();
     }
 
-        public boolean retainAll(Collection<?> c) {
+    public boolean retainAll(Collection<?> c) {
         throw new Error();
     }
 
-        public boolean addAll(Collection<? extends V> collection) {
+    public boolean addAll(Collection<? extends V> collection) {
         throw new Error();
     }
 
-        public boolean contains(Object o) {
+    public boolean contains(Object o) {
         throw new Error();
     }
 
-        public boolean containsAll(Collection<?> c) {
+    public boolean containsAll(Collection<?> c) {
         throw new Error();
     }
 
-        public boolean add(V value) {
+    public boolean add(V value) {
         throw new Error();
     }
 
-        public <T> T[] toArray(T[] type) {
+    public <T> T[] toArray(T[] type) {
         throw new Error();
     }
 
-        public Object[] toArray() {
+    public Object[] toArray() {
         throw new Error();
     }
 
-        public boolean isEmpty() {
+    public boolean isEmpty() {
         throw new Error();
     }
 }

--- a/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
+++ b/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
@@ -10,68 +10,55 @@ class WrappedSet<K, V> implements Set<V> {
         throw new Error();
     }
 
-    @Override
-    public int size() {
+        public int size() {
         throw new Error();
     }
 
-    @Override
-    public Iterator<V> iterator() {
+        public Iterator<V> iterator() {
         throw new Error();
     }
 
-    @Override
-    public void clear() {
+        public void clear() {
         throw new Error();
     }
 
-    @Override
-    public boolean remove(Object o) {
+        public boolean remove(Object o) {
         throw new Error();
     }
 
-    @Override
-    public boolean removeAll(Collection<?> c) {
+        public boolean removeAll(Collection<?> c) {
         throw new Error();
     }
 
-    @Override
-    public boolean retainAll(Collection<?> c) {
+        public boolean retainAll(Collection<?> c) {
         throw new Error();
     }
 
-    @Override
-    public boolean addAll(Collection<? extends V> collection) {
+        public boolean addAll(Collection<? extends V> collection) {
         throw new Error();
     }
 
-    @Override
-    public boolean contains(Object o) {
+        public boolean contains(Object o) {
         throw new Error();
     }
 
-    @Override
-    public boolean containsAll(Collection<?> c) {
+        public boolean containsAll(Collection<?> c) {
         throw new Error();
     }
 
-    @Override
-    public boolean add(V value) {
+        public boolean add(V value) {
         throw new Error();
     }
 
-    @Override
-    public <T> T[] toArray(T[] type) {
+        public <T> T[] toArray(T[] type) {
         throw new Error();
     }
 
-    @Override
-    public Object[] toArray() {
+        public Object[] toArray() {
         throw new Error();
     }
 
-    @Override
-    public boolean isEmpty() {
+        public boolean isEmpty() {
         throw new Error();
     }
 }

--- a/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
+++ b/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
@@ -17,21 +17,6 @@ class WrappedSet<K, V> implements Set<V> {
     }
 
     @Override
-    public boolean equals(Object object) {
-        throw new Error();
-    }
-
-    @Override
-    public int hashCode() {
-        throw new Error();
-    }
-
-    @Override
-    public String toString() {
-        throw new Error();
-    }
-
-    @Override
     public Iterator<V> iterator() {
         throw new Error();
     }

--- a/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
+++ b/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
@@ -1,0 +1,98 @@
+package com.example;
+
+import java.util.Set;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Collection;
+
+class WrappedSet<K, V> implements Set<V> {
+
+    WrappedSet(K key, Set<V> delegate) {
+        throw new Error();
+    }
+
+    @Override
+    public int size() {
+        throw new Error();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        throw new Error();
+    }
+
+    @Override
+    public int hashCode() {
+        throw new Error();
+    }
+
+    @Override
+    public String toString() {
+        throw new Error();
+    }
+
+    @Override
+    public Iterator<V> iterator() {
+        throw new Error();
+    }
+
+    @Override
+    public Spliterator<V> spliterator() {
+        throw new Error();
+    }
+
+    @Override
+    public void clear() {
+        throw new Error();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new Error();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new Error();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new Error();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends V> collection) {
+        throw new Error();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        throw new Error();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        throw new Error();
+    }
+
+    @Override
+    public boolean add(V value) {
+        throw new Error();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] type) {
+        throw new Error();
+    }
+
+    @Override
+    public Object[] toArray() {
+        throw new Error();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
+++ b/src/test/resources/abstractimpl/expected/com/example/WrappedSet.java
@@ -2,7 +2,6 @@ package com.example;
 
 import java.util.Set;
 import java.util.Iterator;
-import java.util.Spliterator;
 import java.util.Collection;
 
 class WrappedSet<K, V> implements Set<V> {
@@ -18,11 +17,6 @@ class WrappedSet<K, V> implements Set<V> {
 
     @Override
     public Iterator<V> iterator() {
-        throw new Error();
-    }
-
-    @Override
-    public Spliterator<V> spliterator() {
         throw new Error();
     }
 

--- a/src/test/resources/abstractimpl/input/com/example/Simple.java
+++ b/src/test/resources/abstractimpl/input/com/example/Simple.java
@@ -7,7 +7,7 @@ import com.example.WrappedSet;
 
 public class Simple<K, V> {
     // Target method.
-    Collection<V> bar(K Key, Collection<V> collection) {
+    Collection<V> bar(K key, Collection<V> collection) {
         return new WrappedSet(key, (Set<V>) collection);
     }
 }

--- a/src/test/resources/abstractimpl/input/com/example/Simple.java
+++ b/src/test/resources/abstractimpl/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.Set;
+import java.util.Collection;
+
+import com.example.WrappedSet;
+
+public class Simple<K, V> {
+    // Target method.
+    Collection<V> bar(K Key, Collection<V> collection) {
+        return new WrappedSet(key, (Set<V>) collection);
+    }
+}

--- a/src/test/resources/abstractimpl/input/com/example/WrappedSet.java
+++ b/src/test/resources/abstractimpl/input/com/example/WrappedSet.java
@@ -1,0 +1,98 @@
+package com.example;
+
+import java.util.Set;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Collection;
+
+class WrappedSet<K, V> implements Set<V> {
+
+    WrappedSet(K key, Set<V> delegate) {
+        throw new Error();
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return "hello world";
+    }
+
+    @Override
+    public Iterator<V> iterator() {
+        return null;
+    }
+
+    @Override
+    public Spliterator<V> spliterator() {
+        return null;
+    }
+
+    @Override
+    public void clear() {
+
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return false;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return false;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return false;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends V> collection) {
+        return false;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return false;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return false;
+    }
+
+    @Override
+    public boolean add(V value) {
+        return false;
+    }
+
+    @Override
+    public <T> T[] toArray(T[] type) {
+        return null;
+    }
+
+    @Override
+    public Object[] toArray() {
+        return null;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+}

--- a/src/test/resources/abstractoverride/expected/com/example/AbstractSimple.java
+++ b/src/test/resources/abstractoverride/expected/com/example/AbstractSimple.java
@@ -1,0 +1,4 @@
+package com.example;
+
+abstract class AbstractSimple {
+}

--- a/src/test/resources/abstractoverride/expected/com/example/Simple.java
+++ b/src/test/resources/abstractoverride/expected/com/example/Simple.java
@@ -1,0 +1,7 @@
+package com.example;
+
+class Simple extends AbstractSimple {
+
+    void bar() {
+    }
+}

--- a/src/test/resources/abstractoverride/input/com/example/AbstractSimple.java
+++ b/src/test/resources/abstractoverride/input/com/example/AbstractSimple.java
@@ -1,0 +1,5 @@
+package com.example;
+
+abstract class AbstractSimple {
+    Object baz(Object obj);
+}

--- a/src/test/resources/abstractoverride/input/com/example/Simple.java
+++ b/src/test/resources/abstractoverride/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+class Simple extends AbstractSimple {
+    // Target method, no content
+    void bar() {
+    }
+
+    // This method is abstract in AbstractSimple.
+    @Override
+    Object baz(Object obj) {
+        return obj.toString();
+    }
+}

--- a/src/test/resources/abstractoverride2/expected/com/example/Simple.java
+++ b/src/test/resources/abstractoverride2/expected/com/example/Simple.java
@@ -1,0 +1,7 @@
+package com.example;
+
+class Simple {
+
+    void bar() {
+    }
+}

--- a/src/test/resources/abstractoverride2/input/com/example/AbstractSimple.java
+++ b/src/test/resources/abstractoverride2/input/com/example/AbstractSimple.java
@@ -1,0 +1,5 @@
+package com.example;
+
+interface AbstractSimple {
+    Object baz(Object obj);
+}

--- a/src/test/resources/abstractoverride2/input/com/example/Simple.java
+++ b/src/test/resources/abstractoverride2/input/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+class Simple implements AbstractSimple {
+    // Target method, no content
+    void bar() {
+    }
+
+    // This method is abstract in AbstractSimple.
+    @Override
+    Object baz(Object obj) {
+        return obj.toString();
+    }
+}

--- a/src/test/resources/anonymousclass/expected/com/example/Simple.java
+++ b/src/test/resources/anonymousclass/expected/com/example/Simple.java
@@ -8,7 +8,7 @@ public class Simple {
         int localVar = 42;
         SomeClass myObject = new SomeClass() {
 
-                        public int getLocalVar() {
+            public int getLocalVar() {
                 return localVar;
             }
         };

--- a/src/test/resources/anonymousclass/expected/com/example/Simple.java
+++ b/src/test/resources/anonymousclass/expected/com/example/Simple.java
@@ -8,8 +8,7 @@ public class Simple {
         int localVar = 42;
         SomeClass myObject = new SomeClass() {
 
-            @Override
-            public int getLocalVar() {
+                        public int getLocalVar() {
                 return localVar;
             }
         };

--- a/src/test/resources/innerclasscomplex/expected/com/example/AbstractAnalysis.java
+++ b/src/test/resources/innerclasscomplex/expected/com/example/AbstractAnalysis.java
@@ -13,7 +13,7 @@ public abstract class AbstractAnalysis {
         public class ForwardDFOComparator implements Comparator<Block> {
 
             @SuppressWarnings("nullness:unboxing.of.nullable")
-                        public int compare(Block b1, Block b2) {
+            public int compare(Block b1, Block b2) {
                 return depthFirstOrder.get(b1) - depthFirstOrder.get(b2);
             }
         }

--- a/src/test/resources/innerclasscomplex/expected/com/example/AbstractAnalysis.java
+++ b/src/test/resources/innerclasscomplex/expected/com/example/AbstractAnalysis.java
@@ -13,8 +13,7 @@ public abstract class AbstractAnalysis {
         public class ForwardDFOComparator implements Comparator<Block> {
 
             @SuppressWarnings("nullness:unboxing.of.nullable")
-            @Override
-            public int compare(Block b1, Block b2) {
+                        public int compare(Block b1, Block b2) {
                 return depthFirstOrder.get(b1) - depthFirstOrder.get(b2);
             }
         }

--- a/src/test/resources/interfaceimplemented/expected/com/example/Foo.java
+++ b/src/test/resources/interfaceimplemented/expected/com/example/Foo.java
@@ -2,7 +2,7 @@ package com.example;
 
 class Foo implements Baz {
 
-        public void doSomething() {
+    public void doSomething() {
         System.out.println("Foo is doing something!");
     }
 }

--- a/src/test/resources/interfaceimplemented/expected/com/example/Foo.java
+++ b/src/test/resources/interfaceimplemented/expected/com/example/Foo.java
@@ -2,8 +2,7 @@ package com.example;
 
 class Foo implements Baz {
 
-    @Override
-    public void doSomething() {
+        public void doSomething() {
         System.out.println("Foo is doing something!");
     }
 }

--- a/src/test/resources/interfacemethodwithunsolvedtype/expected/com/example/Foo.java
+++ b/src/test/resources/interfacemethodwithunsolvedtype/expected/com/example/Foo.java
@@ -4,8 +4,7 @@ import org.testing.UnsolvedType;
 
 class Foo implements Baz<String> {
 
-    @Override
-    public UnsolvedType doSomething(String value) {
+        public UnsolvedType doSomething(String value) {
         System.out.println("Foo is doing something with: " + value);
         return null;
     }

--- a/src/test/resources/interfacemethodwithunsolvedtype/expected/com/example/Foo.java
+++ b/src/test/resources/interfacemethodwithunsolvedtype/expected/com/example/Foo.java
@@ -4,7 +4,7 @@ import org.testing.UnsolvedType;
 
 class Foo implements Baz<String> {
 
-        public UnsolvedType doSomething(String value) {
+    public UnsolvedType doSomething(String value) {
         System.out.println("Foo is doing something with: " + value);
         return null;
     }

--- a/src/test/resources/interfacewithgenerictype/expected/com/example/Foo.java
+++ b/src/test/resources/interfacewithgenerictype/expected/com/example/Foo.java
@@ -2,8 +2,7 @@ package com.example;
 
 class Foo implements Baz<String> {
 
-    @Override
-    public void doSomething(String value) {
+        public void doSomething(String value) {
         System.out.println("Foo is doing something with: " + value);
     }
 }

--- a/src/test/resources/interfacewithgenerictype/expected/com/example/Foo.java
+++ b/src/test/resources/interfacewithgenerictype/expected/com/example/Foo.java
@@ -2,7 +2,7 @@ package com.example;
 
 class Foo implements Baz<String> {
 
-        public void doSomething(String value) {
+    public void doSomething(String value) {
         System.out.println("Foo is doing something with: " + value);
     }
 }

--- a/src/test/resources/interfacewithunsolvedsymbols/expected/com/example/Foo.java
+++ b/src/test/resources/interfacewithunsolvedsymbols/expected/com/example/Foo.java
@@ -2,8 +2,7 @@ package com.example;
 
 class Foo implements Baz<String> {
 
-    @Override
-    public void doSomething(String value) {
+        public void doSomething(String value) {
         System.out.println("Foo is doing something with: " + value);
     }
 }

--- a/src/test/resources/interfacewithunsolvedsymbols/expected/com/example/Foo.java
+++ b/src/test/resources/interfacewithunsolvedsymbols/expected/com/example/Foo.java
@@ -2,7 +2,7 @@ package com.example;
 
 class Foo implements Baz<String> {
 
-        public void doSomething(String value) {
+    public void doSomething(String value) {
         System.out.println("Foo is doing something with: " + value);
     }
 }

--- a/src/test/resources/superclass/expected/com/example/Simple.java
+++ b/src/test/resources/superclass/expected/com/example/Simple.java
@@ -7,8 +7,7 @@ class BigSimple {
 }
 
 public class Simple extends BigSimple {
-    @Override
-    public void printMessage() {
+        public void printMessage() {
         super.printMessage();
         BigSimple obj = new BigSimple();
     }

--- a/src/test/resources/superclass/expected/com/example/Simple.java
+++ b/src/test/resources/superclass/expected/com/example/Simple.java
@@ -7,7 +7,7 @@ class BigSimple {
 }
 
 public class Simple extends BigSimple {
-        public void printMessage() {
+    public void printMessage() {
         super.printMessage();
         BigSimple obj = new BigSimple();
     }


### PR DESCRIPTION
This prevents warnings like this one, in the integration test cf-3022, when compiling Specimin's output:
```
./com/google/common/collect/AbstractMapBasedMultimap.java:114: error: AbstractMapBasedMultimap.WrappedCollection is not abstract and does not override abstract method size() in AbstractCollection
    class WrappedCollection extends AbstractCollection<V> {
    ^
```

The key problem is making sure that we preserve methods that are necessary because an abstract class/interface doesn't actually define an implementation for them.