### PR TITLE
Handle cases when the target class extends an inner class.

### DIFF
--- a/src/main/java/org/checkerframework/specimin/InheritancePreserveVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/InheritancePreserveVisitor.java
@@ -57,9 +57,36 @@ public class InheritancePreserveVisitor extends ModifierVisitor<Void> {
         catch (UnsolvedSymbolException | UnsupportedOperationException e) {
           continue;
         }
-        addedClasses.add(qualifiedName);
+        updateAddedClassWithQualifiedClassName(qualifiedName);
       }
     }
     return super.visit(decl, p);
+  }
+
+  /**
+   * (This method is copied from TargetMethodFinderVisitor).
+   *
+   * <p>Updates the list of used classes with the given qualified class name and its corresponding
+   * primary classes and enclosing classes. This includes cases such as classes not sharing the same
+   * name as their Java files or nested classes.
+   *
+   * @param qualifiedClassName The qualified class name to be included in the list of used classes.
+   */
+  public void updateAddedClassWithQualifiedClassName(String qualifiedClassName) {
+    // in case of type variables
+    if (!qualifiedClassName.contains(".")) {
+      return;
+    }
+    // strip type variables, if they're present
+    if (qualifiedClassName.contains("<")) {
+      qualifiedClassName = qualifiedClassName.substring(0, qualifiedClassName.indexOf("<"));
+    }
+    addedClasses.add(qualifiedClassName);
+
+    String potentialOuterClass =
+        qualifiedClassName.substring(0, qualifiedClassName.lastIndexOf("."));
+    if (UnsolvedSymbolVisitor.isAClassPath(potentialOuterClass)) {
+      updateAddedClassWithQualifiedClassName(potentialOuterClass);
+    }
   }
 }

--- a/src/test/java/org/checkerframework/specimin/InnerClassUsageTest.java
+++ b/src/test/java/org/checkerframework/specimin/InnerClassUsageTest.java
@@ -1,0 +1,15 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test checks if Specimin can handle when the target class extends an inner class. */
+public class InnerClassUsageTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "innerclassusage",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#test()"});
+  }
+}

--- a/src/test/resources/innerclassusage/expected/com/example/Baz.java
+++ b/src/test/resources/innerclassusage/expected/com/example/Baz.java
@@ -1,0 +1,14 @@
+package com.example;
+
+public class Baz {
+
+    public static class InnerBaz {
+
+        public static class NestedInnerBaz {
+
+            public void test() {
+                throw new Error();
+            }
+        }
+    }
+}

--- a/src/test/resources/innerclassusage/expected/com/example/Foo.java
+++ b/src/test/resources/innerclassusage/expected/com/example/Foo.java
@@ -1,0 +1,9 @@
+package com.example;
+
+public class Foo extends Baz.InnerBaz.NestedInnerBaz {
+
+    @Override
+    public void test() {
+        return null;
+    }
+}

--- a/src/test/resources/innerclassusage/expected/com/example/Foo.java
+++ b/src/test/resources/innerclassusage/expected/com/example/Foo.java
@@ -4,6 +4,6 @@ public class Foo extends Baz.InnerBaz.NestedInnerBaz {
 
     @Override
     public void test() {
-        return null;
+        return;
     }
 }

--- a/src/test/resources/innerclassusage/input/com/example/Baz.java
+++ b/src/test/resources/innerclassusage/input/com/example/Baz.java
@@ -1,0 +1,21 @@
+package com.example;
+
+public class Baz {
+
+    public static class InnerBaz {
+
+        public void toBeRemovedToo() {
+            throw new Error();
+        }
+
+        public static class NestedInnerBaz {
+            public void test() {
+                System.out.println("Hello World");
+            }
+
+            public void toBeRemoved() {
+                throw new Error();
+            }
+        }
+    }
+}

--- a/src/test/resources/innerclassusage/input/com/example/Foo.java
+++ b/src/test/resources/innerclassusage/input/com/example/Foo.java
@@ -1,0 +1,9 @@
+package com.example;
+
+public class Foo extends Baz.InnerBaz.NestedInnerBaz {
+
+    @Override
+    public void test() {
+        return null;
+    }
+}

--- a/src/test/resources/innerclassusage/input/com/example/Foo.java
+++ b/src/test/resources/innerclassusage/input/com/example/Foo.java
@@ -4,6 +4,6 @@ public class Foo extends Baz.InnerBaz.NestedInnerBaz {
 
     @Override
     public void test() {
-        return null;
+        return;
     }
 }


### PR DESCRIPTION
Professor,

This PR uses the update method from `TargetMethodFinderVisitor` to update the list of extended classes more comprehensively. Please take a look. Thank you.