### PR TITLE
Consider all abstracts for built-in packages of the Java language.

### DIFF
--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -135,9 +135,7 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
    * @return true iff the input is non-null and abstract
    */
   private boolean isPreservedAndAbstract(@Nullable ResolvedMethodDeclaration method) {
-    return method != null
-        && method.isAbstract()
-        && usedMembers.contains(method.getQualifiedSignature());
+    return method != null && method.isAbstract();
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -135,7 +135,16 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
    * @return true iff the input is non-null and abstract
    */
   private boolean isPreservedAndAbstract(@Nullable ResolvedMethodDeclaration method) {
-    return method != null && method.isAbstract();
+    if (method == null || !method.isAbstract()) {
+      return false;
+    }
+    String methodSignature = method.getQualifiedSignature();
+    // These classes are beyond our control. It's better to retain the implementations of all
+    // abstract methods to ensure the code remains compilable.
+    if (methodSignature.startsWith("java.")) {
+      return true;
+    }
+    return usedMembers.contains(methodSignature);
   }
 
   /**

--- a/src/main/resources/min_program_compile_status.json
+++ b/src/main/resources/min_program_compile_status.json
@@ -10,7 +10,7 @@
   "cf-3850": "FAIL",
   "cf-577": "FAIL",
   "cf-3032": "FAIL",
-  "cf-3619": "FAIL",
+  "cf-3619": "PASS",
   "cf-3021": "FAIL",
   "cf-3020": "PASS",
   "cf-3022": "FAIL",


### PR DESCRIPTION
Professor,

This PR updates the `MustImplementMethodsVisitor` to consider all overriding methods as should be preserved if they are overriding abstract methods from the built-in packages of Java. 

Please take a look. Thank you.