### PR TITLE
Preserve wildcard imports

### DIFF
--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -1,7 +1,6 @@
 package org.checkerframework.specimin;
 
 import com.github.javaparser.StaticJavaParser;
-import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
@@ -127,21 +126,14 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
       // the result of getNameAsString is actually the package name. This renaming is just to
       // make the code less confusing.
       String importedPackage = classFullName;
-      // the parent of an import is always the corresponding compilation unit, thanks to the
-      // JLS' requirements about the placement of import statements (JLS 7.3)
-      CompilationUnit parent = (CompilationUnit) decl.getParentNode().orElseThrow();
-      decl.remove();
+      boolean isUsedAtLeastOnce = false;
       for (String usedClassFQN : classesUsedByTargetMethods) {
         if (usedClassFQN.startsWith(importedPackage)) {
-          try {
-            parent.addImport(usedClassFQN);
-          } catch (com.github.javaparser.ParseProblemException e) {
-            // ParseProblemException is not very helpful for figuring out what the problem is
-            // if we make a bug that causes it to be thrown (it only prints out the part of
-            // the type that is the problem, not the whole type).
-            throw new RuntimeException("failed trying to parse this import: " + usedClassFQN, e);
-          }
+          isUsedAtLeastOnce = true;
         }
+      }
+      if (!isUsedAtLeastOnce) {
+        decl.remove();
       }
       return decl;
     }

--- a/src/test/resources/wildcardimport/expected/com/example/Simple.java
+++ b/src/test/resources/wildcardimport/expected/com/example/Simple.java
@@ -1,7 +1,6 @@
 package com.example;
 
-import org.example.Foo;
-import org.example.FooMethodReturnType;
+import org.example.*;
 
 class Simple {
     void bar() {

--- a/src/test/resources/wildcardimport2/expected/com/example/Simple.java
+++ b/src/test/resources/wildcardimport2/expected/com/example/Simple.java
@@ -1,7 +1,6 @@
 package com.example;
 
-import org.example.Foo;
-import org.example.FooMethodReturnType;
+import org.example.*;
 
 class Simple {
     void bar() {

--- a/src/test/resources/wildcardimport3/expected/com/example/Simple.java
+++ b/src/test/resources/wildcardimport3/expected/com/example/Simple.java
@@ -1,6 +1,6 @@
 package com.example;
 
-import org.anotherexample.Foo;
+import org.anotherexample.*;
 
 class Simple {
     void bar() {


### PR DESCRIPTION
This PR fixes some compilation errors in `cf-6030`. The problem occurs because not all classes have access to every class in the list of used classes. So, it's risky to transform a wildcard import based on that list. Unfortunately, I couldn't find a good way to write a test case to show this bug.