### PR TITLE
Type var consistency

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
@@ -39,8 +39,8 @@ public class UnsolvedClassOrInterface {
   /** This field records the number of type variables for this class */
   private int numberOfTypeVariables = 0;
 
-  /** This field records the name of type variables for this class as it is used */
-  private Set<String> preferedTypeVariables = new HashSet<>();
+  /** This field records the name of type variables that we prefer this class to have. */
+  private Set<String> preferredTypeVariables = new HashSet<>();
 
   /** The field records the extends/implements clauses, if one exists. */
   private @Nullable String extendsClause;
@@ -181,12 +181,12 @@ public class UnsolvedClassOrInterface {
   }
 
   /**
-   * Set the value for preferedTypeVariables.
+   * Set the value for preferredTypeVariables.
    *
-   * @param preferedTypeVariables desired value for preferedTypeVariables.
+   * @param preferredTypeVariables desired value for preferredTypeVariables.
    */
-  public void setPreferedTypeVariables(Set<String> preferedTypeVariables) {
-    this.preferedTypeVariables = preferedTypeVariables;
+  public void setPreferedTypeVariables(Set<String> preferredTypeVariables) {
+    this.preferredTypeVariables = preferredTypeVariables;
   }
 
   /**
@@ -366,13 +366,13 @@ public class UnsolvedClassOrInterface {
    * @param result a string builder. Will be side-effected.
    */
   private void getTypeVariablesImpl(StringBuilder result) {
-    if (preferedTypeVariables.size() == 0) {
+    if (preferredTypeVariables.size() == 0) {
       for (int i = 0; i < numberOfTypeVariables; i++) {
         String typeExpression = "T" + ((i > 0) ? i : "");
         result.append(typeExpression).append(", ");
       }
     } else {
-      for (String preferedTypeVar : preferedTypeVariables) {
+      for (String preferedTypeVar : preferredTypeVariables) {
         result.append(preferedTypeVar).append(", ");
       }
     }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
@@ -39,6 +39,9 @@ public class UnsolvedClassOrInterface {
   /** This field records the number of type variables for this class */
   private int numberOfTypeVariables = 0;
 
+  /** This field records the name of type variables for this class as it is used */
+  private Set<String> preferedTypeVariables = new HashSet<>();
+
   /** The field records the extends/implements clauses, if one exists. */
   private @Nullable String extendsClause;
 
@@ -175,6 +178,15 @@ public class UnsolvedClassOrInterface {
    */
   public void setNumberOfTypeVariables(int numberOfTypeVariables) {
     this.numberOfTypeVariables = numberOfTypeVariables;
+  }
+
+  /**
+   * Set the value for preferedTypeVariables.
+   *
+   * @param preferedTypeVariables desired value for preferedTypeVariables.
+   */
+  public void setPreferedTypeVariables(Set<String> preferedTypeVariables) {
+    this.preferedTypeVariables = preferedTypeVariables;
   }
 
   /**
@@ -354,9 +366,15 @@ public class UnsolvedClassOrInterface {
    * @param result a string builder. Will be side-effected.
    */
   private void getTypeVariablesImpl(StringBuilder result) {
-    for (int i = 0; i < numberOfTypeVariables; i++) {
-      String typeExpression = "T" + ((i > 0) ? i : "");
-      result.append(typeExpression).append(", ");
+    if (preferedTypeVariables.size() == 0) {
+      for (int i = 0; i < numberOfTypeVariables; i++) {
+        String typeExpression = "T" + ((i > 0) ? i : "");
+        result.append(typeExpression).append(", ");
+      }
+    } else {
+      for (String preferedTypeVar : preferedTypeVariables) {
+        result.append(preferedTypeVar).append(", ");
+      }
     }
     result.delete(result.length() - 2, result.length());
   }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
@@ -1,6 +1,5 @@
 package org.checkerframework.specimin;
 
-import com.google.common.base.Ascii;
 import java.util.List;
 import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -132,15 +131,7 @@ public class UnsolvedMethod {
     }
     String returnTypeInString = "";
     if (!returnType.equals("")) {
-      // This is hard-coding. We believe that a single capital character is a generic type. And
-      // since synthetic classes created by Specimin uses "T" for generic types, we need to change
-      // the return type to
-      // "T" accordingly.
-      if (returnType.length() == 1 && returnType.equals(Ascii.toUpperCase(returnType))) {
-        returnTypeInString = "T ";
-      } else {
-        returnTypeInString = returnType + " ";
-      }
+      returnTypeInString = returnType + " ";
     }
     String staticField = "";
     if (isStatic) {

--- a/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedMethod.java
@@ -1,5 +1,6 @@
 package org.checkerframework.specimin;
 
+import com.google.common.base.Ascii;
 import java.util.List;
 import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -131,7 +132,15 @@ public class UnsolvedMethod {
     }
     String returnTypeInString = "";
     if (!returnType.equals("")) {
-      returnTypeInString = returnType + " ";
+      // This is hard-coding. We believe that a single capital character is a generic type. And
+      // since synthetic classes created by Specimin uses "T" for generic types, we need to change
+      // the return type to
+      // "T" accordingly.
+      if (returnType.length() == 1 && returnType.equals(Ascii.toUpperCase(returnType))) {
+        returnTypeInString = "T ";
+      } else {
+        returnTypeInString = returnType + " ";
+      }
     }
     String staticField = "";
     if (isStatic) {

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1197,20 +1197,16 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    */
   private void solveSymbolsForClassOrInterfaceType(
       ClassOrInterfaceType typeExpr, boolean isAnInterface) {
-    System.out.println("Solving for type: " + typeExpr);
     Optional<NodeList<Type>> typeArguments = typeExpr.getTypeArguments();
     UnsolvedClassOrInterface classToUpdate;
     int numberOfArguments = 0;
     String typeRawName = typeExpr.getElementType().asString();
-    Set<String> preferedTypeVariables = new HashSet<>();
+    Set<String> preferredTypeVariables = new HashSet<>();
     if (typeArguments.isPresent()) {
       numberOfArguments = typeArguments.get().size();
       for (Type typeArgument : typeArguments.get()) {
-        System.out.println(typeVariables);
-        System.out.println(isTypeVar(typeArgument.asString()));
         if (isTypeVar(typeArgument.toString())) {
-          System.out.println("Got type var!");
-          preferedTypeVariables.add(typeArgument.toString());
+          preferredTypeVariables.add(typeArgument.toString());
         }
       }
       // without any type argument
@@ -1228,7 +1224,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     classToUpdate = new UnsolvedClassOrInterface(className, packageName, false, isAnInterface);
 
     classToUpdate.setNumberOfTypeVariables(numberOfArguments);
-    classToUpdate.setPreferedTypeVariables(preferedTypeVariables);
+    classToUpdate.setPreferedTypeVariables(preferredTypeVariables);
     updateMissingClass(classToUpdate);
   }
 
@@ -1940,7 +1936,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       } else if (type.isArray()) {
         parametersList.add(type.asArrayType().describe());
       } else if (type.isTypeVariable()) {
-        parametersList.add(type.toString());
+        parametersList.add(type.asTypeVariable().describe());
       }
     }
     return parametersList;

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1209,6 +1209,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
           preferredTypeVariables.add(typeArgument.toString());
         }
       }
+      if (!preferredTypeVariables.isEmpty() && preferredTypeVariables.size() != numberOfArguments) {
+        throw new RuntimeException("Numbers of type variables are not matching!");
+      }
       // without any type argument
       typeRawName = typeRawName.substring(0, typeRawName.indexOf("<"));
     }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1927,6 +1927,8 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         parametersList.add(type.describe());
       } else if (type.isArray()) {
         parametersList.add(type.asArrayType().describe());
+      } else if (type.isTypeVariable()) {
+        parametersList.add("T");
       }
     }
     return parametersList;

--- a/src/test/java/org/checkerframework/specimin/TypeVarMatchingTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarMatchingTest.java
@@ -1,0 +1,15 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test makes sure that the use of a type variable in a synthetic file is consistent. */
+public class TypeVarMatchingTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "typevarmatching",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#get(E)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/TypeVarMatchingTest.java
+++ b/src/test/java/org/checkerframework/specimin/TypeVarMatchingTest.java
@@ -3,7 +3,10 @@ package org.checkerframework.specimin;
 import java.io.IOException;
 import org.junit.Test;
 
-/** This test makes sure that the use of a type variable in a synthetic file is consistent. */
+/**
+ * This test checks that the names of type variables of a synthetic class match the names of those
+ * type variables when the class is used.
+ */
 public class TypeVarMatchingTest {
   @Test
   public void runTest() throws IOException {

--- a/src/test/resources/typevarmatching/expected/com/example/Simple.java
+++ b/src/test/resources/typevarmatching/expected/com/example/Simple.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.testing.SimpleParent;
+
+class Simple<E> extends SimpleParent<E> {
+
+    public E get(E input) {
+        System.out.println("Child method");
+        return super.get(input);
+    }
+}

--- a/src/test/resources/typevarmatching/expected/com/example/Simple.java
+++ b/src/test/resources/typevarmatching/expected/com/example/Simple.java
@@ -2,9 +2,9 @@ package com.example;
 
 import org.testing.SimpleParent;
 
-class Simple<E> extends SimpleParent<E> {
+class Simple<E, V> extends SimpleParent<E, V> {
 
-    public E get(E input) {
+    public V get(E input) {
         System.out.println("Child method");
         return super.get(input);
     }

--- a/src/test/resources/typevarmatching/expected/org/testing/SimpleParent.java
+++ b/src/test/resources/typevarmatching/expected/org/testing/SimpleParent.java
@@ -1,0 +1,8 @@
+package org.testing;
+
+public class SimpleParent<T> {
+
+    public T get(T parameter0) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/typevarmatching/expected/org/testing/SimpleParent.java
+++ b/src/test/resources/typevarmatching/expected/org/testing/SimpleParent.java
@@ -1,8 +1,8 @@
 package org.testing;
 
-public class SimpleParent<T> {
+public class SimpleParent<E, V> {
 
-    public T get(T parameter0) {
+    public V get(E parameter0) {
         throw new Error();
     }
 }

--- a/src/test/resources/typevarmatching/input/com/example/Simple.java
+++ b/src/test/resources/typevarmatching/input/com/example/Simple.java
@@ -2,8 +2,8 @@ package com.example;
 
 import org.testing.SimpleParent;
 
-class Simple<E> extends SimpleParent<E> {
-    public E get(E input) {
+class Simple<E, V> extends SimpleParent<E, V> {
+    public V get(E input) {
         System.out.println("Child method");
         return super.get(input);
     }

--- a/src/test/resources/typevarmatching/input/com/example/Simple.java
+++ b/src/test/resources/typevarmatching/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.testing.SimpleParent;
+
+class Simple<E> extends SimpleParent<E> {
+    public E get(E input) {
+        System.out.println("Child method");
+        return super.get(input);
+    }
+}


### PR DESCRIPTION
Professor,

This PR introduces a new field in `UnsolvedClassOrInterfaceType` to make sure that we don't have compilation error due to mismatches in type variables. 

In the provided test case, if we have `SimpleParent<T, T1>`, there arises a potential issue when the javac updates the synthetic type of `get()` to `V`. This update would result in a type variable mismatch within the `SimpleParent` class.

Please take a look. Thank you.