### PR TITLE
Make CF-3850 compilable

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
+++ b/src/main/java/org/checkerframework/specimin/JavaLangUtils.java
@@ -7,13 +7,25 @@ import java.util.Set;
 public final class JavaLangUtils {
 
   /**
-   * Checks if the given simple name is a member of the java.lang package.
+   * Checks if the given simple name is a member of the java.lang package. This method returns false
+   * for primitive names (e.g., "int").
    *
    * @param simpleName a simple name
    * @return true if this name is defined by java.lang
    */
   public static boolean isJavaLangName(String simpleName) {
     return javaLangClassesAndInterfaces.contains(simpleName);
+  }
+
+  /**
+   * Checks if the given simple name is a member of the java.lang package. This method also returns
+   * true for primitive types (like "int").
+   *
+   * @param simpleName a simple name
+   * @return true if the name is defined by java.lang or is a primitive
+   */
+  public static boolean isJavaLangOrPrimitiveName(String simpleName) {
+    return primitives.contains(simpleName) || javaLangClassesAndInterfaces.contains(simpleName);
   }
 
   /** Don't call this. */
@@ -28,7 +40,19 @@ public final class JavaLangUtils {
    */
   private static final Set<String> javaLangClassesAndInterfaces = new HashSet<>();
 
+  /** Internal set for the names of the primitive types. */
+  private static final Set<String> primitives = new HashSet<>(8);
+
   static {
+    primitives.add("int");
+    primitives.add("short");
+    primitives.add("byte");
+    primitives.add("long");
+    primitives.add("boolean");
+    primitives.add("float");
+    primitives.add("double");
+    primitives.add("char");
+
     javaLangClassesAndInterfaces.add("AbstractMethodError");
     javaLangClassesAndInterfaces.add("Appendable");
     javaLangClassesAndInterfaces.add("ArithmeticException");

--- a/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
+++ b/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
@@ -272,17 +272,28 @@ class JavaTypeCorrect {
     if (typeToChange.containsKey(incorrectType)) {
       String otherCorrectType = typeToChange.get(incorrectType);
       if (!otherCorrectType.equals(correctType)) {
-        // we require a LUB: don't do a direct conversion between the types, but
-        // instead retain the "incorrect" synthetic type as a mutual top type
-        // for the two other "correct" types.
-        typeToChange.remove(incorrectType);
-        // TODO: what if one of these "correct" types is non-synthetic?
-        // Is that possible? What would the consequences be if so?
-        extendedTypes.put(correctType, incorrectType);
-        extendedTypes.put(otherCorrectType, incorrectType);
-        // once we've made this lub correction, we don't want to
-        // continue with our main fix strategy
-        return;
+        boolean isSyntheticReturnType = incorrectType.endsWith("ReturnType");
+        if (!isSyntheticReturnType) {
+          // we require a LUB: don't do a direct conversion between the types, but
+          // instead retain the "incorrect" synthetic type as a mutual top type
+          // for the two other "correct" types.
+          typeToChange.remove(incorrectType);
+          // TODO: what if one of these "correct" types is non-synthetic?
+          // Is that possible? What would the consequences be if so?
+          extendedTypes.put(correctType, incorrectType);
+          extendedTypes.put(otherCorrectType, incorrectType);
+          // once we've made this lub correction, we don't want to
+          // continue with our main fix strategy
+          return;
+        } else {
+          // we require a GLB: that is, this synthetic return type needs to _used_ in
+          // two different contexts: one where correctType is required, and another
+          // where otherCorrectType is required. Instead of worrying about making a correct GLB,
+          // instead just use an unconstrained type variable.
+          typeToChange.put(
+              incorrectType, "<SyntheticUnconstrainedType> SyntheticUnconstrainedType");
+          return;
+        }
       }
     }
 

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -2735,6 +2735,11 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       boolean updateAField,
       String incorrectTypeName,
       String correctTypeName) {
+    // make sure that correctTypeName is fully qualified, so that we don't need to
+    // add an import to the synthetic class
+    if (!isAClassPath(correctTypeName)) {
+      correctTypeName = getPackageFromClassName(correctTypeName) + "." + correctTypeName;
+    }
     boolean updatedSuccessfully = false;
     UnsolvedClassOrInterface classToSearch = new UnsolvedClassOrInterface(className, packageName);
     Iterator<UnsolvedClassOrInterface> iterator = missingClass.iterator();

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1897,7 +1897,12 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         parametersList.add(((ResolvedReferenceType) type).getQualifiedName());
       } else if (type.isPrimitive()) {
         parametersList.add(type.describe());
+      } else if (type.isNull()) {
+        // No way to know what the type should be, so use top.
+        parametersList.add("Object");
       }
+      // TODO: should we raise an exception here if there is some other kind of type? Could
+      // any other type (e.g., a type variable) possibly flow here? I think it's possible.
     }
     return parametersList;
   }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -2735,10 +2735,17 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       boolean updateAField,
       String incorrectTypeName,
       String correctTypeName) {
-    // make sure that correctTypeName is fully qualified, so that we don't need to
-    // add an import to the synthetic class
-    if (!isAClassPath(correctTypeName)) {
-      correctTypeName = getPackageFromClassName(correctTypeName) + "." + correctTypeName;
+    // Make sure that correctTypeName is fully qualified, so that we don't need to
+    // add an import to the synthetic class.
+    if (!isAClassPath(correctTypeName)
+        && !JavaLangUtils.isJavaLangOrPrimitiveName(correctTypeName)) {
+      // Cannot call getPackageFromClassName here, because correctTypeName
+      // might be a type variable, and this method is called after the visitor finishes
+      // running.
+      String pkgName = classAndPackageMap.get(correctTypeName);
+      if (pkgName != null) {
+        correctTypeName = pkgName + "." + correctTypeName;
+      }
     }
     boolean updatedSuccessfully = false;
     UnsolvedClassOrInterface classToSearch = new UnsolvedClassOrInterface(className, packageName);

--- a/src/main/resources/min_program_compile_status.json
+++ b/src/main/resources/min_program_compile_status.json
@@ -7,7 +7,7 @@
   "cf-6030b": "PASS",
   "cf-6019": "PASS",
   "cf-4614": "PASS",
-  "cf-3850": "FAIL",
+  "cf-3850": "PASS",
   "cf-577": "FAIL",
   "cf-3032": "FAIL",
   "cf-3619": "PASS",

--- a/src/test/java/org/checkerframework/specimin/LambdaBodyStaticUnsolved2Test.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaBodyStaticUnsolved2Test.java
@@ -1,0 +1,26 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that a statically-imported, unsolved method used in the body of a lambda has an
+ * appropriate/compatible synthetic method created for it. This version of the test adds another use
+ * of the used method that has different typing constraints as a distractor, mimicking a problem
+ * that showed up in CF-3850.
+ */
+public class LambdaBodyStaticUnsolved2Test {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdabodystaticunsolved2",
+        new String[] {
+          "com/example/Simple.java",
+          "com/example/sql/SqlNode.java",
+          "com/example/sql/SqlParserPos.java",
+          "com/example/util/Util.java",
+          "com/example/AnotherClass.java"
+        },
+        new String[] {"com.example.Simple#toPos(Iterable<? extends SqlNode>)"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/LambdaBodyStaticUnsolvedTest.java
+++ b/src/test/java/org/checkerframework/specimin/LambdaBodyStaticUnsolvedTest.java
@@ -1,0 +1,23 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that a statically-imported, unsolved method used in the body of a lambda has an
+ * appropriate/compatible snythetic method created for it.
+ */
+public class LambdaBodyStaticUnsolvedTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "lambdabodystaticunsolved",
+        new String[] {
+          "com/example/Simple.java",
+          "com/example/sql/SqlNode.java",
+          "com/example/sql/SqlParserPos.java",
+          "com/example/util/Util.java"
+        },
+        new String[] {"com.example.Simple#toPos(Iterable<? extends SqlNode>)"});
+  }
+}

--- a/src/test/resources/lambdabodystaticunsolved/expected/com/example/Simple.java
+++ b/src/test/resources/lambdabodystaticunsolved/expected/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+import static com.example.nullness.Nullness.castNonNull;
+
+class Simple {
+
+    private static Iterable<SqlParserPos> toPos(Iterable<? extends SqlNode> nodes) {
+        return Util.transform(nodes, node -> node == null ? castNonNull(null) : node.getParserPosition());
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved/expected/com/example/nullness/Nullness.java
+++ b/src/test/resources/lambdabodystaticunsolved/expected/com/example/nullness/Nullness.java
@@ -2,7 +2,7 @@ package com.example.nullness;
 
 public class Nullness {
 
-    public static com.example.sql.SqlParserPos castNonNull(Object parameter0) {
+    public static com.example.sql.SqlParserPos castNonNull(java.lang.Object parameter0) {
         throw new Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved/expected/com/example/nullness/Nullness.java
+++ b/src/test/resources/lambdabodystaticunsolved/expected/com/example/nullness/Nullness.java
@@ -1,8 +1,10 @@
 package com.example.nullness;
 
+import com.example.sql.SqlParserPos;
+
 public class Nullness {
 
-    public static <T extends Object> T castNonNull(T t) {
+    public static SqlParserPos castNonNull(Object parameter0) {
         throw new Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved/expected/com/example/nullness/Nullness.java
+++ b/src/test/resources/lambdabodystaticunsolved/expected/com/example/nullness/Nullness.java
@@ -1,10 +1,8 @@
 package com.example.nullness;
 
-import com.example.sql.SqlParserPos;
-
 public class Nullness {
 
-    public static SqlParserPos castNonNull(Object parameter0) {
+    public static com.example.sql.SqlParserPos castNonNull(Object parameter0) {
         throw new Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved/expected/com/example/nullness/Nullness.java
+++ b/src/test/resources/lambdabodystaticunsolved/expected/com/example/nullness/Nullness.java
@@ -1,0 +1,8 @@
+package com.example.nullness;
+
+public class Nullness {
+
+    public static <T extends Object> T castNonNull(T t) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved/expected/com/example/sql/SqlNode.java
+++ b/src/test/resources/lambdabodystaticunsolved/expected/com/example/sql/SqlNode.java
@@ -1,0 +1,7 @@
+package com.example.sql;
+
+public class SqlNode {
+    public SqlParserPos getParserPosition() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved/expected/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/lambdabodystaticunsolved/expected/com/example/sql/SqlParserPos.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlParserPos {
+}

--- a/src/test/resources/lambdabodystaticunsolved/expected/com/example/util/Util.java
+++ b/src/test/resources/lambdabodystaticunsolved/expected/com/example/util/Util.java
@@ -1,0 +1,7 @@
+package com.example.util;
+
+public class Util {
+    public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable, java.util.function.Function<? super F, ? extends T> function) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved/input/com/example/Simple.java
+++ b/src/test/resources/lambdabodystaticunsolved/input/com/example/Simple.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+// Note: intentionally not in the input, so a synthetic class + method
+// needs to be created.
+import static com.example.nullness.Nullness.castNonNull;
+
+class Simple {
+    // Target method.
+    private static Iterable<SqlParserPos> toPos(
+            Iterable<? extends SqlNode> nodes) {
+        return Util.transform(nodes,
+                node -> node == null ? castNonNull(null) : node.getParserPosition());
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved/input/com/example/sql/SqlNode.java
+++ b/src/test/resources/lambdabodystaticunsolved/input/com/example/sql/SqlNode.java
@@ -1,0 +1,7 @@
+package com.example.sql;
+
+public class SqlNode {
+    public SqlParserPos getParserPosition() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved/input/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/lambdabodystaticunsolved/input/com/example/sql/SqlParserPos.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlParserPos {
+}

--- a/src/test/resources/lambdabodystaticunsolved/input/com/example/util/Util.java
+++ b/src/test/resources/lambdabodystaticunsolved/input/com/example/util/Util.java
@@ -1,0 +1,8 @@
+package com.example.util;
+
+public class Util {
+    public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable,
+                                               java.util.function.Function<? super F, ? extends T> function) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved2/expected/com/example/Simple.java
+++ b/src/test/resources/lambdabodystaticunsolved2/expected/com/example/Simple.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+import static com.example.nullness.Nullness.castNonNull;
+
+class Simple {
+
+    private static Iterable<SqlParserPos> toPos(Iterable<? extends SqlNode> nodes) {
+        return Util.transform(nodes, node -> node == null ? castNonNull(null) : node.getParserPosition());
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved2/expected/com/example/nullness/Nullness.java
+++ b/src/test/resources/lambdabodystaticunsolved2/expected/com/example/nullness/Nullness.java
@@ -2,7 +2,7 @@ package com.example.nullness;
 
 public class Nullness {
 
-    public static com.example.sql.SqlParserPos castNonNull(Object parameter0) {
+    public static <SyntheticUnconstrainedType> SyntheticUnconstrainedType castNonNull(Object parameter0) {
         throw new Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved2/expected/com/example/nullness/Nullness.java
+++ b/src/test/resources/lambdabodystaticunsolved2/expected/com/example/nullness/Nullness.java
@@ -2,7 +2,7 @@ package com.example.nullness;
 
 public class Nullness {
 
-    public static <SyntheticUnconstrainedType> SyntheticUnconstrainedType castNonNull(Object parameter0) {
+    public static <SyntheticUnconstrainedType> SyntheticUnconstrainedType castNonNull(java.lang.Object parameter0) {
         throw new Error();
     }
 }

--- a/src/test/resources/lambdabodystaticunsolved2/expected/com/example/nullness/Nullness.java
+++ b/src/test/resources/lambdabodystaticunsolved2/expected/com/example/nullness/Nullness.java
@@ -1,0 +1,8 @@
+package com.example.nullness;
+
+public class Nullness {
+
+    public static com.example.sql.SqlParserPos castNonNull(Object parameter0) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved2/expected/com/example/sql/SqlNode.java
+++ b/src/test/resources/lambdabodystaticunsolved2/expected/com/example/sql/SqlNode.java
@@ -1,0 +1,7 @@
+package com.example.sql;
+
+public class SqlNode {
+    public SqlParserPos getParserPosition() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved2/expected/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/lambdabodystaticunsolved2/expected/com/example/sql/SqlParserPos.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlParserPos {
+}

--- a/src/test/resources/lambdabodystaticunsolved2/expected/com/example/util/Util.java
+++ b/src/test/resources/lambdabodystaticunsolved2/expected/com/example/util/Util.java
@@ -1,0 +1,7 @@
+package com.example.util;
+
+public class Util {
+    public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable, java.util.function.Function<? super F, ? extends T> function) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved2/input/com/example/AnotherClass.java
+++ b/src/test/resources/lambdabodystaticunsolved2/input/com/example/AnotherClass.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import static com.example.nullness.Nullness.castNonNull;
+
+public class AnotherClass {
+
+    public static AnotherClass distractor() {
+        return castNonNull(null);
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved2/input/com/example/Simple.java
+++ b/src/test/resources/lambdabodystaticunsolved2/input/com/example/Simple.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import com.example.sql.SqlNode;
+import com.example.sql.SqlParserPos;
+import com.example.util.Util;
+
+// Note: intentionally not in the input, so a synthetic class + method
+// needs to be created.
+import static com.example.nullness.Nullness.castNonNull;
+
+class Simple {
+    // Target method.
+    private static Iterable<SqlParserPos> toPos(
+            Iterable<? extends SqlNode> nodes) {
+        return Util.transform(nodes,
+                node -> node == null ? castNonNull(null) : node.getParserPosition());
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved2/input/com/example/sql/SqlNode.java
+++ b/src/test/resources/lambdabodystaticunsolved2/input/com/example/sql/SqlNode.java
@@ -1,0 +1,7 @@
+package com.example.sql;
+
+public class SqlNode {
+    public SqlParserPos getParserPosition() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/lambdabodystaticunsolved2/input/com/example/sql/SqlParserPos.java
+++ b/src/test/resources/lambdabodystaticunsolved2/input/com/example/sql/SqlParserPos.java
@@ -1,0 +1,4 @@
+package com.example.sql;
+
+public class SqlParserPos {
+}

--- a/src/test/resources/lambdabodystaticunsolved2/input/com/example/util/Util.java
+++ b/src/test/resources/lambdabodystaticunsolved2/input/com/example/util/Util.java
@@ -1,0 +1,8 @@
+package com.example.util;
+
+public class Util {
+    public static <F, T> Iterable<T> transform(Iterable<? extends F> iterable,
+                                               java.util.function.Function<? super F, ? extends T> function) {
+        throw new Error();
+    }
+}


### PR DESCRIPTION
This PR contains three related fixes, all of which are necessary to get CF-3850 (and therefore the new test case in this PR) to compile:
* we need to add something to the list of arguments for a synthetic method as a placeholder if `null` is passed. This PR just adds "Object" there.
* the strategy for handling constraints in JavaTypeCorrect has changed to handle constraints with multiple types in them (they're comma-separated). This is necessary to trigger the appropriate type correction so that the return type of `castNonNull` is compatible with the lambda (there are two lower bounds).
* `updateTypeForSyntheticClasses` has been changed to attempt to use a fully-qualified name when possible, because otherwise there is an unsolved symbol once we correctly mark the return type of `castNonNull` as `SqlParserPos` (a simple name from javac's output) in the test case.

This PR is currently a draft because it passes the test cases locally but doesn't actually fix CF-3850's last remaining error. I'm investigating why it fails now.