### PR TITLE
Correctly preserve methods with a null argument

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -515,27 +515,14 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       return super.visit(node, arg);
     } catch (Exception e) {
       NodeList<Expression> arguments = node.getArguments();
-      List<String> parametersList = new ArrayList<>();
-      for (Expression parameter : arguments) {
-        if (!canBeSolved(parameter)) {
-          return super.visit(node, arg);
-        }
-        ResolvedType type = parameter.calculateResolvedType();
-        if (type instanceof PrimitiveType) {
-          parametersList.add(type.asPrimitive().name());
-        } else if (type instanceof ReferenceType) {
-          parametersList.add(type.asReferenceType().getQualifiedName());
-        } else if (type instanceof NullType) {
-          parametersList.add("java.lang.Object");
-        }
-      }
+      String pkgName = getPackageFromClassName(getParentClass(className));
+      List<String> argList = getArgumentTypesImpl(arguments, pkgName);
       UnsolvedMethod constructorMethod =
-          new UnsolvedMethod(getParentClass(className), "", parametersList);
+          new UnsolvedMethod(getParentClass(className), "", argList);
       // if the parent class can not be found in the import statements, Specimin assumes it is in
       // the same package as the child class.
       UnsolvedClassOrInterface superClass =
-          new UnsolvedClassOrInterface(
-              getParentClass(className), getPackageFromClassName(getParentClass(className)));
+          new UnsolvedClassOrInterface(getParentClass(className), pkgName);
       superClass.addMethod(constructorMethod);
       updateMissingClass(superClass);
       return super.visit(node, arg);

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -32,7 +32,6 @@ import com.github.javaparser.ast.stmt.SwitchEntry;
 import com.github.javaparser.ast.stmt.TryStmt;
 import com.github.javaparser.ast.stmt.WhileStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.TypeParameter;
@@ -48,7 +47,6 @@ import com.github.javaparser.resolution.types.ResolvedLambdaConstraintType;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.resolution.types.ResolvedTypeVariable;
-import com.github.javaparser.symbolsolver.model.typesystem.NullType;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
 import com.github.javaparser.utils.Pair;
 import com.google.common.base.Ascii;
@@ -517,8 +515,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       NodeList<Expression> arguments = node.getArguments();
       String pkgName = getPackageFromClassName(getParentClass(className));
       List<String> argList = getArgumentTypesImpl(arguments, pkgName);
-      UnsolvedMethod constructorMethod =
-          new UnsolvedMethod(getParentClass(className), "", argList);
+      UnsolvedMethod constructorMethod = new UnsolvedMethod(getParentClass(className), "", argList);
       // if the parent class can not be found in the import statements, Specimin assumes it is in
       // the same package as the child class.
       UnsolvedClassOrInterface superClass =

--- a/src/main/resources/min_program_compile_status.json
+++ b/src/main/resources/min_program_compile_status.json
@@ -14,7 +14,7 @@
   "cf-3021": "PASS",
   "cf-3020": "PASS",
   "cf-3022": "FAIL",
-  "cf-691": "FAIL",
+  "cf-691": "PASS",
   "Issue689": "FAIL",
   "cf-6388": "PASS"
 }

--- a/src/test/java/org/checkerframework/specimin/NullArgTest.java
+++ b/src/test/java/org/checkerframework/specimin/NullArgTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that methods used in the target that are only called with null arguments are
+ * preserved correctly.
+ */
+public class NullArgTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "nullarg",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar(Baz)"});
+  }
+}

--- a/src/test/resources/nullarg/expected/com/example/Simple.java
+++ b/src/test/resources/nullarg/expected/com/example/Simple.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import org.example.Baz;
+
+class Simple {
+    void bar(Baz baz) {
+        baz.qux(null);
+    }
+}

--- a/src/test/resources/nullarg/expected/org/example/Baz.java
+++ b/src/test/resources/nullarg/expected/org/example/Baz.java
@@ -2,7 +2,7 @@ package org.example;
 
 public class Baz {
 
-    QuxReturnType qux(Object parameter0) {
+    public QuxReturnType qux(java.lang.Object parameter0) {
         throw new Error();
     }
 }

--- a/src/test/resources/nullarg/expected/org/example/Baz.java
+++ b/src/test/resources/nullarg/expected/org/example/Baz.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Baz {
+
+    QuxReturnType qux(Object parameter0) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/nullarg/expected/org/example/QuxReturnType.java
+++ b/src/test/resources/nullarg/expected/org/example/QuxReturnType.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public class QuxReturnType {
+
+}

--- a/src/test/resources/nullarg/input/com/example/Simple.java
+++ b/src/test/resources/nullarg/input/com/example/Simple.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import org.example.Baz;
+
+class Simple {
+    // Target method.
+    void bar(Baz baz) {
+        baz.qux(null);
+    }
+}


### PR DESCRIPTION
This PR also includes a significant refactoring to unite the code that's used for inferring parameter types from arguments. Previously, we had three copies of it (only one of which has been modified by @LoiNguyenCS's recent PRs) - one for method call expressions, another for object creation expressions, and a third for explicit constructor invocations. Now all these locations call into the same routine (derived from the method call code), so fixes in one location will apply to all three.