### PR TITLE
Remove completely unresolvable interfaces

### DIFF
--- a/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
+++ b/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
@@ -53,7 +53,7 @@ class JavaTypeCorrect {
   private Map<String, String> extendedTypes = new HashMap<>();
 
   /**
-   * /** This map associates the name of a class with the name of the unresolved interface due to
+   * This map associates the name of a class with the name of the unresolved interface due to
    * missing method implementations.
    */
   private Map<String, String> classAndUnresolvedInterface = new HashMap<>();
@@ -166,7 +166,7 @@ class JavaTypeCorrect {
         // source codes to begin with. This usually happens when a file is isolated from its
         // package, and its parent is supposed to override some of the methods in the given
         // interface. For these cases, if the interface is not from Java language, we will modify
-        // the codes of the interface. Otherwise, we will remove that interface completely..
+        // the codes of the interface. Otherwise, we will remove that interface completely.
         if (line.contains("not abstract and does not override abstract method")) {
           updateClassAndUnresolvedInterface(line);
         }

--- a/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
+++ b/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
@@ -167,6 +167,10 @@ class JavaTypeCorrect {
         // package, and its parent is supposed to override some of the methods in the given
         // interface. For these cases, if the interface is not from Java language, we will modify
         // the codes of the interface. Otherwise, we will remove that interface completely.
+
+        // TODO: Update Specimin to generate a synthetic version for the missing parent class with
+        // synthetic method implementations, particularly if the targeted method invokes a method
+        // from the parent class that implements a method from a Java language interface.
         if (line.contains("not abstract and does not override abstract method")) {
           updateClassAndUnresolvedInterface(line);
         }

--- a/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
+++ b/src/main/java/org/checkerframework/specimin/JavaTypeCorrect.java
@@ -53,10 +53,10 @@ class JavaTypeCorrect {
   private Map<String, String> extendedTypes = new HashMap<>();
 
   /**
-   * The map connects the name of a class to the name of the interface that should be removed from
-   * the declaration of that class.
+   * /** This map associates the name of a class with the name of the unresolved interface due to
+   * missing method implementations.
    */
-  private Map<String, String> classAndInterfacesToBeRemoved = new HashMap<>();
+  private Map<String, String> classAndUnresolvedInterface = new HashMap<>();
 
   /**
    * Create a new JavaTypeCorrect instance. The directories of files in fileNameList are relative to
@@ -85,12 +85,12 @@ class JavaTypeCorrect {
   }
 
   /**
-   * Get the value of classAndInterfacesToBeRemoved.
+   * Get the value of classAndUnresolvedInterface.
    *
-   * @return the value of classAndInterfacesToBeRemoved.
+   * @return the value of classAndUnresolvedInterface.
    */
-  public Map<String, String> getClassAndInterfacesToBeRemoved() {
-    return classAndInterfacesToBeRemoved;
+  public Map<String, String> getClassAndUnresolvedInterface() {
+    return classAndUnresolvedInterface;
   }
 
   /**
@@ -168,7 +168,7 @@ class JavaTypeCorrect {
         // interface. For these cases, if the interface is not from Java language, we will modify
         // the codes of the interface. Otherwise, we will remove that interface completely..
         if (line.contains("not abstract and does not override abstract method")) {
-          updateInterfacesToRemove(line);
+          updateClassAndUnresolvedInterface(line);
         }
         if (line.contains("error: incompatible types")) {
           updateTypeToChange(line, filePath);
@@ -324,12 +324,12 @@ class JavaTypeCorrect {
   }
 
   /**
-   * This method updates the map of classes and their to-be-removed interfaces based on an error
+   * This method updates the map of classes and their unresolved interfaces based on an error
    * message from javac.
    *
    * @param line an error message from javac.
    */
-  private void updateInterfacesToRemove(String line) {
+  private void updateClassAndUnresolvedInterface(String line) {
     List<String> splitErrorMessage = Splitter.onPattern("\\s+").splitToList(line);
     // such an error message will have this format:
     // <Location> error: <Class> is not abstract and does not override abstract method <Method> in
@@ -340,7 +340,7 @@ class JavaTypeCorrect {
     }
     String className = splitErrorMessage.get(2);
     String interfaceName = splitErrorMessage.get(splitErrorMessage.size() - 1);
-    classAndInterfacesToBeRemoved.put(className, interfaceName);
+    classAndUnresolvedInterface.put(className, interfaceName);
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -85,8 +85,8 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
    */
   private final Set<String> resolvedYetStuckMethodCall;
 
-  /** This map connects a class and its unresolvable interface. */
-  private Map<String, String> classAndInterfaceToRemoved;
+  /** This map connects a class and its unresolved interface. */
+  private Map<String, String> classAndUnresolvedInterface;
 
   /**
    * Creates the pruner. All members this pruner encounters other than those in its input sets will
@@ -101,17 +101,18 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
    * @param classesUsedByTargetMethods the classes used by target methods
    * @param resolvedYetStuckMethodCall set of methods that are resolved yet can not be solved by
    *     JavaParser
+   * @param classAndUnresolvedInterface connects a class to its corresponding unresolved interface
    */
   public PrunerVisitor(
       Set<String> methodsToKeep,
       Set<String> membersToEmpty,
       Set<String> classesUsedByTargetMethods,
       Set<String> resolvedYetStuckMethodCall,
-      Map<String, String> classAndInterfaceToRemoved) {
+      Map<String, String> classAndUnresolvedInterface) {
     this.methodsToLeaveUnchanged = methodsToKeep;
     this.membersToEmpty = membersToEmpty;
     this.classesUsedByTargetMethods = classesUsedByTargetMethods;
-    this.classAndInterfaceToRemoved = classAndInterfaceToRemoved;
+    this.classAndUnresolvedInterface = classAndUnresolvedInterface;
     Set<String> toRemove = new HashSet<>();
     for (String classUsedByTargetMethods : classesUsedByTargetMethods) {
       if (classUsedByTargetMethods.contains("<")) {
@@ -208,14 +209,14 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
           if (!classesUsedByTargetMethods.contains(typeFullName)) {
             iterator.remove();
           }
-          // all unresolvable interfaces belong the Java package.
+          // all unresolvable interfaces that need to be remove belong to the Java package.
           if (!typeFullName.startsWith("java.")) {
             continue;
           }
-          for (String classNeedInterfaceRemoved : classAndInterfaceToRemoved.keySet()) {
+          for (String classNeedInterfaceRemoved : classAndUnresolvedInterface.keySet()) {
             // since classNeedInterfaceRemoved can be in the form of a simple name
             if (classQualifiedName.endsWith(classNeedInterfaceRemoved)) {
-              if (classAndInterfaceToRemoved
+              if (classAndUnresolvedInterface
                   .get(classNeedInterfaceRemoved)
                   .equals(interfaceType.getNameAsString())) {
                 // This code assumes that the likelihood of two different classes with the same

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -32,7 +32,6 @@ import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
@@ -87,7 +86,7 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
   private final Set<String> resolvedYetStuckMethodCall;
 
   /** This map connects a class and its unresolved interface. */
-  private Map<String, String> classAndUnresolvedInterface;
+  private java.util.Map<String, String> classAndUnresolvedInterface;
 
   /**
    * Creates the pruner. All members this pruner encounters other than those in its input sets will
@@ -109,7 +108,7 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
       Set<String> membersToEmpty,
       Set<String> classesUsedByTargetMethods,
       Set<String> resolvedYetStuckMethodCall,
-      Map<String, String> classAndUnresolvedInterface) {
+      java.util.Map<String, String> classAndUnresolvedInterface) {
     this.methodsToLeaveUnchanged = methodsToKeep;
     this.membersToEmpty = membersToEmpty;
     this.classesUsedByTargetMethods = classesUsedByTargetMethods;

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -33,6 +33,7 @@ import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import org.checkerframework.checker.signature.qual.FullyQualifiedName;

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -209,7 +209,7 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
           if (!classesUsedByTargetMethods.contains(typeFullName)) {
             iterator.remove();
           }
-          // all unresolvable interfaces that need to be remove belong to the Java package.
+          // all unresolvable interfaces that need to be removed belong to the Java package.
           if (!typeFullName.startsWith("java.")) {
             continue;
           }

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -160,6 +160,7 @@ public class SpeciminRunner {
     // files in the end.
     Set<Path> createdClass = new HashSet<>();
     Map<String, String> typesToChange = new HashMap<>();
+    Map<String, String> classAndInterfacesToBeRemoved = new HashMap<>();
     while (addMissingClass.gettingException()) {
       addMissingClass.setExceptionToFalse();
       UnsolvedSymbolVisitorProgress workDoneBeforeIteration =
@@ -216,6 +217,7 @@ public class SpeciminRunner {
             new JavaTypeCorrect(root, new HashSet<>(targetFiles), filesAndAssociatedTypes);
         typeCorrecter.correctTypesForAllFiles();
         typesToChange = typeCorrecter.getTypeToChange();
+        classAndInterfacesToBeRemoved = typeCorrecter.getClassAndInterfacesToBeRemoved();
         boolean changeAtLeastOneType = addMissingClass.updateTypes(typesToChange);
         boolean extendAtLeastOneType =
             addMissingClass.updateTypesWithExtends(typeCorrecter.getExtendedTypes());
@@ -339,7 +341,8 @@ public class SpeciminRunner {
             finder.getTargetMethods(),
             mustImplementMethodsVisitor.getUsedMembers(),
             mustImplementMethodsVisitor.getUsedClass(),
-            finder.getResolvedYetStuckMethodCall());
+            finder.getResolvedYetStuckMethodCall(),
+            classAndInterfacesToBeRemoved);
 
     for (CompilationUnit cu : parsedTargetFiles.values()) {
       cu.accept(methodPruner, null);

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -160,7 +160,7 @@ public class SpeciminRunner {
     // files in the end.
     Set<Path> createdClass = new HashSet<>();
     Map<String, String> typesToChange = new HashMap<>();
-    Map<String, String> classAndInterfacesToBeRemoved = new HashMap<>();
+    Map<String, String> classAndUnresolvedInterface = new HashMap<>();
     while (addMissingClass.gettingException()) {
       addMissingClass.setExceptionToFalse();
       UnsolvedSymbolVisitorProgress workDoneBeforeIteration =
@@ -217,7 +217,7 @@ public class SpeciminRunner {
             new JavaTypeCorrect(root, new HashSet<>(targetFiles), filesAndAssociatedTypes);
         typeCorrecter.correctTypesForAllFiles();
         typesToChange = typeCorrecter.getTypeToChange();
-        classAndInterfacesToBeRemoved = typeCorrecter.getClassAndInterfacesToBeRemoved();
+        classAndUnresolvedInterface = typeCorrecter.getClassAndUnresolvedInterface();
         boolean changeAtLeastOneType = addMissingClass.updateTypes(typesToChange);
         boolean extendAtLeastOneType =
             addMissingClass.updateTypesWithExtends(typeCorrecter.getExtendedTypes());
@@ -342,7 +342,7 @@ public class SpeciminRunner {
             mustImplementMethodsVisitor.getUsedMembers(),
             mustImplementMethodsVisitor.getUsedClass(),
             finder.getResolvedYetStuckMethodCall(),
-            classAndInterfacesToBeRemoved);
+            classAndUnresolvedInterface);
 
     for (CompilationUnit cu : parsedTargetFiles.values()) {
       cu.accept(methodPruner, null);

--- a/src/main/resources/min_program_compile_status.json
+++ b/src/main/resources/min_program_compile_status.json
@@ -8,7 +8,7 @@
   "cf-6019": "PASS",
   "cf-4614": "PASS",
   "cf-3850": "PASS",
-  "cf-577": "FAIL",
+  "cf-577": "PASS",
   "cf-3032": "FAIL",
   "cf-3619": "PASS",
   "cf-3021": "PASS",

--- a/src/test/java/org/checkerframework/specimin/UnsolvableInterfaceTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnsolvableInterfaceTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks if Specimin can handle unsolvable interfaces that happens due to the an input
+ * file is isolated from its codebase. 
+ */
+public class UnsolvableInterfaceTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unsolvableinterface",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo#bar()"});
+  }
+}

--- a/src/test/java/org/checkerframework/specimin/UnsolvableInterfaceTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnsolvableInterfaceTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 /**
  * This test checks if Specimin can handle unsolvable interfaces that happens due to the an input
- * file is isolated from its codebase. 
+ * file is isolated from its codebase.
  */
 public class UnsolvableInterfaceTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/UnsolvableInterfaceTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnsolvableInterfaceTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 /**
  * This test checks if Specimin can handle unsolvable interfaces that happens due to the an input
- * file is isolated from its codebase.
+ * file isolated from its codebase.
  */
 public class UnsolvableInterfaceTest {
   @Test

--- a/src/test/resources/unsolvableinterface/expected/com/example/Baz.java
+++ b/src/test/resources/unsolvableinterface/expected/com/example/Baz.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public class Baz<E> {
+}

--- a/src/test/resources/unsolvableinterface/expected/com/example/Foo.java
+++ b/src/test/resources/unsolvableinterface/expected/com/example/Foo.java
@@ -1,0 +1,8 @@
+package com.example;
+
+class Foo<E> extends Baz<E> {
+
+    public void bar() {
+        System.out.println("Foo is doing something!");
+    }
+}

--- a/src/test/resources/unsolvableinterface/input/com/example/Foo.java
+++ b/src/test/resources/unsolvableinterface/input/com/example/Foo.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.List;
+
+// Suppose this is an isolated Java program from a real life project, and all of the implementation
+// for methods from List are in Baz, then Specimin should simply remove List<E> from the class
+// declaration.
+class Foo<E> extends Baz<E> implements List<E> {
+    public void bar() {
+        System.out.println("Foo is doing something!");
+    }
+
+}

--- a/src/test/resources/unsolvableinterfacehardcase/expected/com/example/AddReturnType.java
+++ b/src/test/resources/unsolvableinterfacehardcase/expected/com/example/AddReturnType.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public class AddReturnType {
+}

--- a/src/test/resources/unsolvableinterfacehardcase/expected/com/example/Baz.java
+++ b/src/test/resources/unsolvableinterfacehardcase/expected/com/example/Baz.java
@@ -1,0 +1,8 @@
+package com.example;
+
+public class Baz<E> {
+
+    public AddReturnType add(E parameter0) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/unsolvableinterfacehardcase/expected/com/example/Foo.java
+++ b/src/test/resources/unsolvableinterfacehardcase/expected/com/example/Foo.java
@@ -1,0 +1,8 @@
+package com.example;
+
+class Foo<E> extends Baz<E> {
+
+    public void bar(E input) {
+        this.add(input);
+    }
+}

--- a/src/test/resources/unsolvableinterfacehardcase/input/com/example/Foo.java
+++ b/src/test/resources/unsolvableinterfacehardcase/input/com/example/Foo.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.List;
+
+// Suppose this is an isolated Java program from a real life project, and all of the implementation
+// for methods from List are in Baz, then Specimin should simply remove List<E> from the class
+// declaration.
+class Foo<E> extends Baz<E> implements List<E> {
+    public void bar(E input) {
+        this.add(input);
+    }
+
+}

--- a/src/test/resources/unsolvableinterfacehardcase/input/com/example/Foo.java
+++ b/src/test/resources/unsolvableinterfacehardcase/input/com/example/Foo.java
@@ -3,8 +3,9 @@ package com.example;
 import java.util.List;
 
 // Suppose this is an isolated Java program from a real life project, and all of the implementation
-// for methods from List are in Baz, then Specimin should simply remove List<E> from the class
-// declaration.
+// for methods from List are in Baz. Then, Specimin removes List<E> from the class declaration,
+// even though add() is called (and creates a synthetic add() method instead). This isn't the right
+// behavior, but Specimin is currently limited without access to the full program.
 class Foo<E> extends Baz<E> implements List<E> {
     public void bar(E input) {
         this.add(input);

--- a/src/test/resources/unsolvableinterfaceprettyhardcase/expected/com/example/Baz.java
+++ b/src/test/resources/unsolvableinterfaceprettyhardcase/expected/com/example/Baz.java
@@ -1,0 +1,101 @@
+package com.example;
+
+import java.util.List;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.ListIterator;
+
+public class Baz<E> implements List<E> {
+
+    public int size() {
+        throw new Error();
+    }
+
+    public boolean isEmpty() {
+        throw new Error();
+    }
+
+    public boolean contains(Object o) {
+        throw new Error();
+    }
+
+    public Iterator<E> iterator() {
+        throw new Error();
+    }
+
+    public Object[] toArray() {
+        throw new Error();
+    }
+
+    public <T> T[] toArray(T[] a) {
+        throw new Error();
+    }
+
+    public boolean add(E e) {
+        throw new Error();
+    }
+
+    public boolean remove(Object o) {
+        throw new Error();
+    }
+
+    public boolean containsAll(Collection<?> c) {
+        throw new Error();
+    }
+
+    public boolean addAll(Collection<? extends E> c) {
+        throw new Error();
+    }
+
+    public boolean addAll(int index, Collection<? extends E> c) {
+        throw new Error();
+    }
+
+    public boolean removeAll(Collection<?> c) {
+        throw new Error();
+    }
+
+    public boolean retainAll(Collection<?> c) {
+        throw new Error();
+    }
+
+    public void clear() {
+        throw new Error();
+    }
+
+    public E get(int index) {
+        throw new Error();
+    }
+
+    public E set(int index, E element) {
+        throw new Error();
+    }
+
+    public void add(int index, E element) {
+        throw new Error();
+    }
+
+    public E remove(int index) {
+        throw new Error();
+    }
+
+    public int indexOf(Object o) {
+        throw new Error();
+    }
+
+    public int lastIndexOf(Object o) {
+        throw new Error();
+    }
+
+    public ListIterator<E> listIterator() {
+        throw new Error();
+    }
+
+    public ListIterator<E> listIterator(int index) {
+        throw new Error();
+    }
+
+    public List<E> subList(int fromIndex, int toIndex) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/unsolvableinterfaceprettyhardcase/expected/com/example/Foo.java
+++ b/src/test/resources/unsolvableinterfaceprettyhardcase/expected/com/example/Foo.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import java.util.List;
+
+class Foo<E> extends Baz<E> implements List<E> {
+
+    public void bar(E input) {
+        this.add(input);
+    }
+}

--- a/src/test/resources/unsolvableinterfaceprettyhardcase/input/com/example/Baz.java
+++ b/src/test/resources/unsolvableinterfaceprettyhardcase/input/com/example/Baz.java
@@ -1,0 +1,130 @@
+package com.example;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.ListIterator;
+
+public class Baz<E> implements List<E> {
+    private ArrayList<E> list;
+
+    public Baz() {
+        list = new ArrayList<>();
+    }
+
+    @Override
+    public int size() {
+        return list.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return list.contains(o);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return list.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return list.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return list.toArray(a);
+    }
+
+    @Override
+    public boolean add(E e) {
+        return list.add(e);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return list.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return list.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        return list.addAll(c);
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends E> c) {
+        return list.addAll(index, c);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return list.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return list.retainAll(c);
+    }
+
+    @Override
+    public void clear() {
+        list.clear();
+    }
+
+    @Override
+    public E get(int index) {
+        return list.get(index);
+    }
+
+    @Override
+    public E set(int index, E element) {
+        return list.set(index, element);
+    }
+
+    @Override
+    public void add(int index, E element) {
+        list.add(index, element);
+    }
+
+    @Override
+    public E remove(int index) {
+        return list.remove(index);
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return list.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return list.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<E> listIterator() {
+        return list.listIterator();
+    }
+
+    @Override
+    public ListIterator<E> listIterator(int index) {
+        return list.listIterator(index);
+    }
+
+    @Override
+    public List<E> subList(int fromIndex, int toIndex) {
+        return list.subList(fromIndex, toIndex);
+    }
+}

--- a/src/test/resources/unsolvableinterfaceprettyhardcase/input/com/example/Foo.java
+++ b/src/test/resources/unsolvableinterfaceprettyhardcase/input/com/example/Foo.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.List;
+
+// Suppose this is an isolated Java program from a real life project, and all of the implementation
+// for methods from List are in Baz, then Specimin should simply remove List<E> from the class
+// declaration.
+class Foo<E> extends Baz<E> implements List<E> {
+    public void bar(E input) {
+        this.add(input);
+    }
+
+}

--- a/src/test/resources/unsolvableinterfaceprettyhardcase/input/com/example/Foo.java
+++ b/src/test/resources/unsolvableinterfaceprettyhardcase/input/com/example/Foo.java
@@ -3,8 +3,8 @@ package com.example;
 import java.util.List;
 
 // Suppose this is an isolated Java program from a real life project, and all of the implementation
-// for methods from List are in Baz, then Specimin should simply remove List<E> from the class
-// declaration.
+// for methods from List are in Baz. Because Baz is present in the input, Specimin can figure out
+// that the call to add() refers to List.add (using the implementation in Baz).
 class Foo<E> extends Baz<E> implements List<E> {
     public void bar(E input) {
         this.add(input);


### PR DESCRIPTION
Professor,

This PR removes interfaces that cannot be resolved for successful compilation  These are interfaces from the java packages. This issue only happens if we isolate the input file from its codebase. Please take a look. Thank you.