### PR TITLE
Enforce Specimin to not create any synthetic classes for packages from Java language

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -2272,6 +2272,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     if (classfileIsInOriginalCodebase(qualifiedName)) {
       return;
     }
+    if (qualifiedName.startsWith("java.")) {
+      return;
+    }
     Iterator<UnsolvedClassOrInterface> iterator = missingClass.iterator();
     while (iterator.hasNext()) {
       UnsolvedClassOrInterface e = iterator.next();


### PR DESCRIPTION
Professor,

Some methods from the classes of the Java language might have generic types, such as `requireNonNull(T)`. These methods will confuse Specimin, making Specimin assumes these methods as unsolved and create corresponding synthetic classes. The solution is simple: we make sure that we don't create any synthetic files for the classes from the Java language.