### PR TITLE
Address the limitation of JavaParser

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1586,6 +1586,15 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    *     files.
    */
   public boolean isFromAJarFile(Expression expr) {
+    ResolvedType resolvedType = expr.calculateResolvedType();
+    if (resolvedType.isTypeVariable()) {
+      // This is a limitation of JavaParser. If a method call has a generic return type, there is no
+      // way to resolve it.
+      // The consequence is that we can not get the class where a method is declared if that method
+      // has a generic return type. Hopefully the later version of JavaParser can address this
+      // limitation.
+      return false;
+    }
     String className;
     if (expr instanceof MethodCallExpr) {
       className =

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1586,21 +1586,21 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    *     files.
    */
   public boolean isFromAJarFile(Expression expr) {
-    ResolvedType resolvedType = expr.calculateResolvedType();
-    if (resolvedType.isTypeVariable()) {
-      // This is a limitation of JavaParser. If a method call has a generic return type, there is no
-      // way to resolve it.
-      // The consequence is that we can not get the class where a method is declared if that method
-      // has a generic return type. Hopefully the later version of JavaParser can address this
-      // limitation.
-      return false;
-    }
     String className;
     if (expr instanceof MethodCallExpr) {
-      className =
-          ((MethodCallExpr) expr).resolve().getPackageName()
-              + "."
-              + ((MethodCallExpr) expr).resolve().getClassName();
+      try {
+        className =
+            ((MethodCallExpr) expr).resolve().getPackageName()
+                + "."
+                + ((MethodCallExpr) expr).resolve().getClassName();
+      } catch (UnsupportedOperationException e) {
+        // This is a limitation of JavaParser. If a method call has a generic return type, sometimes
+        // JavaParser can not resolve it.
+        // The consequence is that we can not get the class where a method is declared if that
+        // method has a generic return type. Hopefully the later version of JavaParser can address
+        // this limitation.
+        return false;
+      }
     } else if (expr instanceof ObjectCreationExpr) {
       String shortName = ((ObjectCreationExpr) expr).getTypeAsString();
       String packageName = classAndPackageMap.get(shortName);


### PR DESCRIPTION
Professor,

This PR fixes one of the crashes in #221.

I can not figure out the specific case where `JavaParser` will fail if there are generic types, hence the word "sometimes" in the explanatory comments. It seems to be that we need to have a generic type with generic bound or something similar for `JavaParser` to fail.

Right now this limitation of `JavaParser` only affect the jar mode, so it is not too serious.  

Please take a look. Thank you.
"