### PR TITLE
Don't create raw types

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -2032,7 +2032,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         // avoid creating methods with raw parameter types
         int ctypevar = rrType.getTypeParametersMap().size();
         String typevars = "";
-        if (ctypevar == 0) {
+        if (ctypevar != 0) {
           typevars =
               "<"
                   + String.join(", ", Collections.nCopies(ctypevar, "?").toArray(new String[0]))

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -61,6 +61,7 @@ import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -2027,7 +2028,17 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       // for reference type, we need the fully-qualified name to avoid having to add additional
       // import statements.
       if (type.isReferenceType()) {
-        parametersList.add(((ResolvedReferenceType) type).getQualifiedName());
+        ResolvedReferenceType rrType = (ResolvedReferenceType) type;
+        // avoid creating methods with raw parameter types
+        int ctypevar = rrType.getTypeParametersMap().size();
+        String typevars = "";
+        if (ctypevar == 0) {
+          typevars =
+              "<"
+                  + String.join(", ", Collections.nCopies(ctypevar, "?").toArray(new String[0]))
+                  + ">";
+        }
+        parametersList.add(rrType.getQualifiedName() + typevars);
       } else if (type.isPrimitive()) {
         parametersList.add(type.describe());
       } else if (type.isArray()) {

--- a/src/test/java/org/checkerframework/specimin/InterfaceUseComplexTest.java
+++ b/src/test/java/org/checkerframework/specimin/InterfaceUseComplexTest.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks if Specimin properly preserves a method in an interface that actually gets used
+ * by a field of that interface's type.
+ */
+public class InterfaceUseComplexTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "interfaceusecomplex",
+        new String[] {"com/example/Foo.java"},
+        new String[] {"com.example.Foo.Qux#containsAll(Baz<?>)"});
+  }
+}

--- a/src/test/resources/interfaceusecomplex/expected/com/example/Baz.java
+++ b/src/test/resources/interfaceusecomplex/expected/com/example/Baz.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public interface Baz<E> {
+    public default boolean containsAll(com.example.Baz<?> parameter0) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/interfaceusecomplex/expected/com/example/Foo.java
+++ b/src/test/resources/interfaceusecomplex/expected/com/example/Foo.java
@@ -1,0 +1,12 @@
+package com.example;
+
+class Foo {
+   static class Qux<E> implements Baz<E> {
+
+       Baz<? extends E> c;
+
+       public boolean containsAll(Baz<?> coll) {
+           return c.containsAll(coll);
+       }
+    }
+}

--- a/src/test/resources/interfaceusecomplex/input/com/example/Foo.java
+++ b/src/test/resources/interfaceusecomplex/input/com/example/Foo.java
@@ -1,0 +1,12 @@
+package com.example;
+
+class Foo {
+   static class Qux<E> implements Baz<E> {
+
+       Baz<? extends E> c;
+
+       public boolean containsAll(Baz<?> coll) {
+           return c.containsAll(coll);
+       }
+    }
+}


### PR DESCRIPTION
Previously, the synthetic method for `containsAll` in `Baz` had the parameter type `com.example.Baz` (without the `<?>`, meaning it is a raw type). There are two problems with that:
* raw types trigger a warning from javac by default
* in this case, it causes the output not to compile (because the implicit override is not correct - the types aren't compatible)

Based on an example I found while investigating cf-691.