### PR TITLE
Use decompiler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 
     implementation "org.vineflower:vineflower:1.10.0"
 
+    implementation 'commons-io:commons-io:2.6'
+
     // Use JUnit test framework.
     testImplementation 'junit:junit:4.13.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 
+    implementation "org.vineflower:vineflower:1.10.0"
+
     // Use JUnit test framework.
     testImplementation 'junit:junit:4.13.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ jar {
     manifest {
         attributes 'Main-Class': 'org.checkerframework.specimin.SpeciminRunner'
     }
+    duplicatesStrategy = 'exclude'
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -321,6 +321,9 @@ public class SpeciminRunner {
         cu.accept(inheritancePreserve, null);
       }
       for (String targetFile : inheritancePreserve.getAddedClasses()) {
+        if (targetFile.startsWith("java.")) {
+          continue;
+        }
         String directoryOfFile = targetFile.replace(".", "/") + ".java";
         File thisFile = new File(root + directoryOfFile);
         // classes from JDK are automatically on the classpath, so UnsolvedSymbolVisitor will not

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -205,6 +205,7 @@ public class SpeciminRunner {
           // These parsing codes cause crashes in the CI. Those crashes can't be reproduced locally.
           // Not sure if something is wrong with VineFlower or Specimin CI. Hence we keep these
           // lines as tech debt.
+          // TODO: Figure out why the CI is crashing.
           continue;
         }
       }
@@ -315,6 +316,7 @@ public class SpeciminRunner {
         try {
           parsedTargetFiles.put(directory, parseJavaFile(root, directory));
         } catch (ParseProblemException e) {
+          // TODO: Figure out why the CI is crashing.
           continue;
         }
       }
@@ -336,6 +338,7 @@ public class SpeciminRunner {
           try {
             parsedTargetFiles.put(directoryOfFile, parseJavaFile(root, directoryOfFile));
           } catch (ParseProblemException e) {
+            // TODO: Figure out why the CI is crashing.
             continue;
           }
         }

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -195,15 +195,13 @@ public class SpeciminRunner {
       updateStaticSolver(root, jarPaths);
       parsedTargetFiles = new HashMap<>();
       for (String targetFile : targetFiles) {
-        try {
-          parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
-        } catch (ParseProblemException e) {
-          // VineFlower is not perfect at decompiling Java files.
-          continue;
-        }
+        parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
       }
       for (String targetFile : addMissingClass.getAddedTargetFiles()) {
-        parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
+        // VineFlower creates additional files from the Java language, which should be ignored.
+        if (!targetFile.startsWith("java.")) {
+          parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
+        }
       }
       UnsolvedSymbolVisitorProgress workDoneAfterIteration =
           new UnsolvedSymbolVisitorProgress(

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -1,5 +1,6 @@
 package org.checkerframework.specimin;
 
+import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
@@ -112,7 +113,12 @@ public class SpeciminRunner {
     // Keys are paths to files, values are parsed ASTs
     Map<String, CompilationUnit> parsedTargetFiles = new HashMap<>();
     for (String targetFile : targetFiles) {
-      parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
+      try {
+        parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
+      } catch (ParseProblemException e) {
+        // VineFlower is not perfect at decompiling Java files.
+        continue;
+      }
     }
 
     if (!jarPaths.isEmpty()) {
@@ -191,10 +197,20 @@ public class SpeciminRunner {
       updateStaticSolver(root, jarPaths);
       parsedTargetFiles = new HashMap<>();
       for (String targetFile : targetFiles) {
-        parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
+        try {
+          parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
+        } catch (ParseProblemException e) {
+          // VineFlower is not perfect at decompiling Java files.
+          continue;
+        }
       }
       for (String targetFile : addMissingClass.getAddedTargetFiles()) {
-        parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
+        try {
+          parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
+        } catch (ParseProblemException e) {
+          // VineFlower is not perfect at decompiling Java files.
+          continue;
+        }
       }
       UnsolvedSymbolVisitorProgress workDoneAfterIteration =
           new UnsolvedSymbolVisitorProgress(
@@ -300,7 +316,12 @@ public class SpeciminRunner {
       // directories already in parsedTargetFiles are original files in the root directory, we are
       // not supposed to update them.
       if (!parsedTargetFiles.containsKey(directory)) {
-        parsedTargetFiles.put(directory, parseJavaFile(root, directory));
+        try {
+          parsedTargetFiles.put(directory, parseJavaFile(root, directory));
+        } catch (ParseProblemException e) {
+          // VineFlower is not perfect at decompiling Java files.
+          continue;
+        }
       }
     }
     Set<String> classToFindInheritance = solveMethodOverridingVisitor.getUsedClass();
@@ -317,7 +338,12 @@ public class SpeciminRunner {
         // classes from JDK are automatically on the classpath, so UnsolvedSymbolVisitor will not
         // create synthetic files for them
         if (thisFile.exists()) {
-          parsedTargetFiles.put(directoryOfFile, parseJavaFile(root, directoryOfFile));
+          try {
+            parsedTargetFiles.put(directoryOfFile, parseJavaFile(root, directoryOfFile));
+          } catch (ParseProblemException e) {
+            // VineFlower is not perfect at decompiling Java files.
+            continue;
+          }
         }
       }
       classToFindInheritance = inheritancePreserve.getAddedClasses();

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -1,6 +1,5 @@
 package org.checkerframework.specimin;
 
-import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
@@ -509,11 +508,7 @@ public class SpeciminRunner {
    *     error
    */
   private static CompilationUnit parseJavaFile(String root, String path) throws IOException {
-    try {
-      return StaticJavaParser.parse(Path.of(root, path));
-    } catch (ParseProblemException e) {
-      throw new Error(root + "." + path + " can not be parsed!");
-    }
+    return StaticJavaParser.parse(Path.of(root, path));
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -114,11 +114,7 @@ public class SpeciminRunner {
     // Keys are paths to files, values are parsed ASTs
     Map<String, CompilationUnit> parsedTargetFiles = new HashMap<>();
     for (String targetFile : targetFiles) {
-      try {
-        parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
-      } catch (Exception e) {
-        throw new Error("Crash here!");
-      }
+      parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
     }
 
     if (!jarPaths.isEmpty()) {
@@ -199,17 +195,12 @@ public class SpeciminRunner {
       updateStaticSolver(root, jarPaths);
       parsedTargetFiles = new HashMap<>();
       for (String targetFile : targetFiles) {
-        try {
-          parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
-        } catch (Exception e) {
-          throw new Error("Crash here1!");
-        }
+        parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
       }
       for (String targetFile : addMissingClass.getAddedTargetFiles()) {
-        try {
+        if (!targetFile.startsWith("java.")) {
+          // VineFlower might create class files for classes from the Java language
           parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
-        } catch (Exception e) {
-          throw new Error("Crash here2!");
         }
       }
       UnsolvedSymbolVisitorProgress workDoneAfterIteration =
@@ -315,12 +306,10 @@ public class SpeciminRunner {
     for (String directory : relatedClass) {
       // directories already in parsedTargetFiles are original files in the root directory, we are
       // not supposed to update them.
-      if (!parsedTargetFiles.containsKey(directory)) {
-        try {
-          parsedTargetFiles.put(directory, parseJavaFile(root, directory));
-        } catch (Exception e) {
-          throw new Error("Crash here4!");
-        }
+      // VineFlower might create class files for classes from the Java language
+
+      if (!parsedTargetFiles.containsKey(directory) && !directory.startsWith("java.")) {
+        parsedTargetFiles.put(directory, parseJavaFile(root, directory));
       }
     }
     Set<String> classToFindInheritance = solveMethodOverridingVisitor.getUsedClass();
@@ -337,11 +326,7 @@ public class SpeciminRunner {
         // classes from JDK are automatically on the classpath, so UnsolvedSymbolVisitor will not
         // create synthetic files for them
         if (thisFile.exists()) {
-          try {
-            parsedTargetFiles.put(directoryOfFile, parseJavaFile(root, directoryOfFile));
-          } catch (Exception e) {
-            throw new Error("Crash here222!");
-          }
+          parsedTargetFiles.put(directoryOfFile, parseJavaFile(root, directoryOfFile));
         }
       }
       classToFindInheritance = inheritancePreserve.getAddedClasses();

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -202,7 +202,7 @@ public class SpeciminRunner {
         try {
           parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
         } catch (ParseProblemException e) {
-          // These parsing codes cause crashes in the CI. Those crahses can't be reproduced locally.
+          // These parsing codes cause crashes in the CI. Those crashes can't be reproduced locally.
           // Not sure if something is wrong with VineFlower or Specimin CI. Hence we keep these
           // lines as tech debt.
           continue;

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -34,6 +34,7 @@ import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
 import org.checkerframework.checker.signature.qual.FullyQualifiedName;
+import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
 
 /** This class is the main runner for Specimin. Use its main() method to start Specimin. */
 public class SpeciminRunner {
@@ -112,6 +113,14 @@ public class SpeciminRunner {
     Map<String, CompilationUnit> parsedTargetFiles = new HashMap<>();
     for (String targetFile : targetFiles) {
       parsedTargetFiles.put(targetFile, parseJavaFile(root, targetFile));
+    }
+
+    if (!jarPaths.isEmpty()) {
+      List<String> argsToDecompile = new ArrayList<>();
+      argsToDecompile.add("--silent");
+      argsToDecompile.addAll(jarPaths);
+      argsToDecompile.add(root);
+      ConsoleDecompiler.main(argsToDecompile.toArray(new String[0]));
     }
 
     // the set of Java classes in the original codebase mapped with their corresponding Java files.

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -328,9 +328,6 @@ public class SpeciminRunner {
         cu.accept(inheritancePreserve, null);
       }
       for (String targetFile : inheritancePreserve.getAddedClasses()) {
-        if (targetFile.startsWith("java.")) {
-          continue;
-        }
         String directoryOfFile = targetFile.replace(".", "/") + ".java";
         File thisFile = new File(root + directoryOfFile);
         // classes from JDK are automatically on the classpath, so UnsolvedSymbolVisitor will not

--- a/src/test/java/org/checkerframework/specimin/JarFileTest.java
+++ b/src/test/java/org/checkerframework/specimin/JarFileTest.java
@@ -8,7 +8,7 @@ public class JarFileTest {
   @Test
   public void runTest() throws IOException {
     SpeciminTestExecutor.runTest(
-        "nodependenciesreturnssame",
+        "jarfile",
         new String[] {"com/example/Simple.java"},
         new String[] {"com.example.Simple#test()"},
         new String[] {"src/test/resources/jarfile/input/Book.jar"});

--- a/src/test/resources/jarfile/expected/an/old/library/Book.java
+++ b/src/test/resources/jarfile/expected/an/old/library/Book.java
@@ -2,11 +2,11 @@ package an.old.library;
 
 public class Book {
 
-    public Book(int parameter0) {
+    public Book(int var1) {
         throw new Error();
     }
 
-    public java.lang.String getRates() {
+    public String getRates() {
         throw new Error();
     }
 }


### PR DESCRIPTION
Professor,

This is the PR to invoke a decompiler. I have decided to use [VineFlower](https://vineflower.org). It is built based on [FernFlower](https://github.com/fesh0r/fernflower). However, VineFlower supports Gradle, and it seems to be [cooler](https://www.reddit.com/r/java/comments/ue8u59/new_open_source_java_decompiler/) according to its creator. :-)

Sorry for adding the try-catch statements when parsing the file. As explained in the comments, it is actually difficult to fix a bug that can't be reproduced locally. But since those bugs do not happen locally., I think we don't have to worry about them.