### PR TITLE
Unsolved return types could be interfaces

### DIFF
--- a/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedClassOrInterface.java
@@ -46,7 +46,7 @@ public class UnsolvedClassOrInterface {
   private @Nullable String extendsClause;
 
   /** This field records if the class is an interface */
-  private final boolean isAnInterface;
+  private boolean isAnInterface;
 
   /**
    * Create an instance of UnsolvedClass. This constructor correctly splits apart the class name and
@@ -105,6 +105,14 @@ public class UnsolvedClassOrInterface {
    */
   public boolean isAnInterface() {
     return isAnInterface;
+  }
+
+  /**
+   * Sets isAnInterface to true. isAnInterface is monotonic: it can start as false and become true
+   * (because we encounter an implements clause), but it can never go from true to false.
+   */
+  public void setIsAnInterfaceToTrue() {
+    this.isAnInterface = true;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1532,7 +1532,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         nodeType.resolve();
       } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
         // Note that this could also be an interface (if it is used in an implements clause elsewhere).
-        // updateMissingClass is responsible for fixing this upper later after we encounter the
+        // updateMissingClass is responsible for fixing this up later after we encounter the
         // relevant implements clause.
         updateUnsolvedClassWithClassName(nodeTypeSimpleForm, false, false);
       }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1531,6 +1531,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       try {
         nodeType.resolve();
       } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
+        // Note that this could also be an interface (if it is used in an implements clause elsewhere).
+        // updateMissingClass is responsible for fixing this upper later after we encounter the
+        // relevant implements clause.
         updateUnsolvedClassWithClassName(nodeTypeSimpleForm, false, false);
       }
     }
@@ -1689,11 +1692,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     // class is in the same directory as the current class
     String packageName = getPackageFromClassName(nameOfClass);
     UnsolvedClassOrInterface result;
-    if (isUpdatingInterface) {
-      result = new UnsolvedClassOrInterface(nameOfClass, packageName, isExceptionType, true);
-    } else {
-      result = new UnsolvedClassOrInterface(nameOfClass, packageName, isExceptionType);
-    }
+    result =
+        new UnsolvedClassOrInterface(
+            nameOfClass, packageName, isExceptionType, isUpdatingInterface);
     for (UnsolvedMethod unsolvedMethod : unsolvedMethods) {
       result.addMethod(unsolvedMethod);
     }
@@ -2337,6 +2338,13 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         if (missedClass.getNumberOfTypeVariables() > 0) {
           e.setNumberOfTypeVariables(missedClass.getNumberOfTypeVariables());
         }
+
+        // if a "class" is found to be an interface even once (because it appears
+        // in an implements clause), then it must be an interface and not a class.
+        if (missedClass.isAnInterface()) {
+          e.setIsAnInterfaceToTrue();
+        }
+
         return;
       }
     }

--- a/src/test/java/org/checkerframework/specimin/NavigableSetExample2.java
+++ b/src/test/java/org/checkerframework/specimin/NavigableSetExample2.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Another test based on NavigableSets in java.util.Collections. This checks for a case where an
+ * unsolved interface was incorrectly being inferred to be a class.
+ */
+public class NavigableSetExample2 {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "navigablesetexample2",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#unmodifiableNavigableSet(NavigableSet<T>)"});
+  }
+}

--- a/src/test/resources/navigablesetexample2/expected/com/example/NavigableSet.java
+++ b/src/test/resources/navigablesetexample2/expected/com/example/NavigableSet.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public interface NavigableSet<E> {
+}

--- a/src/test/resources/navigablesetexample2/expected/com/example/NavigableSet.java
+++ b/src/test/resources/navigablesetexample2/expected/com/example/NavigableSet.java
@@ -1,4 +1,4 @@
 package com.example;
 
-public interface NavigableSet<E> {
+public interface NavigableSet<T> {
 }

--- a/src/test/resources/navigablesetexample2/expected/com/example/Simple.java
+++ b/src/test/resources/navigablesetexample2/expected/com/example/Simple.java
@@ -1,0 +1,27 @@
+package com.example;
+
+/*
+ * Based on an example from java.util.Collections.
+ */
+public class Simple {
+
+    static class UnmodifiableCollection<E> {
+    }
+
+    static class UnmodifiableSet<E> extends UnmodifiableCollection<E> {
+    }
+
+    static class UnmodifiableSortedSet<E> extends UnmodifiableSet<E> {
+    }
+
+    public static <T> NavigableSet<T> unmodifiableNavigableSet(NavigableSet<T> s) {
+        return new UnmodifiableNavigableSet<>(s);
+    }
+
+    static class UnmodifiableNavigableSet<E> extends UnmodifiableSortedSet<E> implements NavigableSet<E> {
+
+        UnmodifiableNavigableSet(NavigableSet<E> s) {
+            throw new Error();
+        }
+    }
+}

--- a/src/test/resources/navigablesetexample2/input/com/example/Simple.java
+++ b/src/test/resources/navigablesetexample2/input/com/example/Simple.java
@@ -1,0 +1,27 @@
+package com.example;
+
+/*
+ * Based on an example from java.util.Collections.
+ */
+public class Simple {
+
+    static class UnmodifiableCollection<E> {
+    }
+
+    static class UnmodifiableSet<E> extends UnmodifiableCollection<E> {
+    }
+
+    static class UnmodifiableSortedSet<E> extends UnmodifiableSet<E> {
+    }
+
+    public static <T> NavigableSet<T> unmodifiableNavigableSet(NavigableSet<T> s) {
+        return new UnmodifiableNavigableSet<>(s);
+    }
+
+    static class UnmodifiableNavigableSet<E> extends UnmodifiableSortedSet<E> implements NavigableSet<E> {
+
+        UnmodifiableNavigableSet(NavigableSet<E> s) {
+            throw new Error();
+        }
+    }
+}


### PR DESCRIPTION
Unfortunately I had to make `isAnInterface` non-final, but I couldn't figure out a way to check whether there is such an `implements` clause at the point where I wrote the new comment around line 1500 (which is the ideal place to fix this).

I also made one small refactoring to get rid of an antipattern.