### PR TITLE
Skip processing explicit constructor invocations until all arguments can be solved

### DIFF
--- a/src/test/java/org/checkerframework/specimin/NavigableSetFieldExample.java
+++ b/src/test/java/org/checkerframework/specimin/NavigableSetFieldExample.java
@@ -1,0 +1,15 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test checks for a crash when targeting a field in the cf-691 example from the JDK. */
+public class NavigableSetFieldExample {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "navigablesetfieldexample",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple.UnmodifiableNavigableSet#EMPTY_NAVIGABLE_SET"});
+  }
+}

--- a/src/test/resources/navigablesetfieldexample/expected/com/example/NavigableSet.java
+++ b/src/test/resources/navigablesetfieldexample/expected/com/example/NavigableSet.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public interface NavigableSet<E> {
+}

--- a/src/test/resources/navigablesetfieldexample/expected/com/example/Simple.java
+++ b/src/test/resources/navigablesetfieldexample/expected/com/example/Simple.java
@@ -1,0 +1,27 @@
+/*
+ * Based on an example from java.util.Collections.
+ */
+package com.example;
+
+public class Simple {
+
+    static class UnmodifiableCollection<E> {
+    }
+
+    static class UnmodifiableSet<E> extends UnmodifiableCollection<E> {
+    }
+
+    static class UnmodifiableSortedSet<E> extends UnmodifiableSet<E> {
+    }
+
+    static class UnmodifiableNavigableSet<E> extends UnmodifiableSortedSet<E> implements NavigableSet<E> {
+
+        @SuppressWarnings("rawtypes")
+        private static final NavigableSet<?> EMPTY_NAVIGABLE_SET = null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E> NavigableSet<E> emptyNavigableSet() {
+        return (NavigableSet<E>) UnmodifiableNavigableSet.EMPTY_NAVIGABLE_SET;
+    }
+}

--- a/src/test/resources/navigablesetfieldexample/expected/com/example/Simple.java
+++ b/src/test/resources/navigablesetfieldexample/expected/com/example/Simple.java
@@ -16,12 +16,14 @@ public class Simple {
 
     static class UnmodifiableNavigableSet<E> extends UnmodifiableSortedSet<E> implements NavigableSet<E> {
 
-        @SuppressWarnings("rawtypes")
-        private static final NavigableSet<?> EMPTY_NAVIGABLE_SET = null;
-    }
+        private static class EmptyNavigableSet<E> extends UnmodifiableNavigableSet<E> {
 
-    @SuppressWarnings("unchecked")
-    public static <E> NavigableSet<E> emptyNavigableSet() {
-        return (NavigableSet<E>) UnmodifiableNavigableSet.EMPTY_NAVIGABLE_SET;
+            public EmptyNavigableSet() {
+                throw new Error();
+            }
+        }
+
+        @SuppressWarnings("rawtypes")
+        private static final NavigableSet<?> EMPTY_NAVIGABLE_SET = new EmptyNavigableSet<>();
     }
 }

--- a/src/test/resources/navigablesetfieldexample/input/com/example/Simple.java
+++ b/src/test/resources/navigablesetfieldexample/input/com/example/Simple.java
@@ -1,0 +1,41 @@
+/*
+ * Based on an example from java.util.Collections.
+ */
+package com.example;
+
+import java.io.Serializable;
+import java.util.TreeSet;
+
+public class Simple {
+
+    static class UnmodifiableCollection<E> {
+        UnmodifiableCollection(Collection<? extends E> c) {
+        }
+    }
+
+    static class UnmodifiableSet<E> extends UnmodifiableCollection<E> {
+        UnmodifiableSet(Set<? extends E> s)     {super(s);}
+    }
+
+    static class UnmodifiableSortedSet<E> extends UnmodifiableSet<E> {
+        UnmodifiableSortedSet(SortedSet<E> s) {super(s); }
+    }
+
+    static class UnmodifiableNavigableSet<E> extends UnmodifiableSortedSet<E> implements NavigableSet<E> {
+        UnmodifiableNavigableSet(NavigableSet<E> s)         {super(s);}
+
+        private static class EmptyNavigableSet<E> extends UnmodifiableNavigableSet<E>
+                implements Serializable {
+            private static final long serialVersionUID = -6291252904449939134L;
+
+            public EmptyNavigableSet() {
+                super(new TreeSet<E>());
+            }
+
+            private Object readResolve()        { return EMPTY_NAVIGABLE_SET; }
+        }
+
+        @SuppressWarnings("rawtypes")
+        private static final NavigableSet<?> EMPTY_NAVIGABLE_SET = new EmptyNavigableSet<>();
+    }
+}

--- a/src/test/resources/navigablesetfieldexample/input/com/example/Simple.java
+++ b/src/test/resources/navigablesetfieldexample/input/com/example/Simple.java
@@ -4,7 +4,6 @@
 package com.example;
 
 import java.io.Serializable;
-import java.util.TreeSet;
 
 public class Simple {
 
@@ -14,7 +13,7 @@ public class Simple {
     }
 
     static class UnmodifiableSet<E> extends UnmodifiableCollection<E> {
-        UnmodifiableSet(Set<? extends E> s)     {super(s);}
+        UnmodifiableSet(Set<? extends E> s1)     {super(s1);}
     }
 
     static class UnmodifiableSortedSet<E> extends UnmodifiableSet<E> {


### PR DESCRIPTION
This adopts the same strategy we use for "regular" method calls.

Fixes one crash on CF-691. However, another is revealed.