### PR TITLE
Preserve the bounds of the type parameters of used classes

### DIFF
--- a/src/main/java/org/checkerframework/specimin/InheritancePreserveVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/InheritancePreserveVisitor.java
@@ -57,6 +57,9 @@ public class InheritancePreserveVisitor extends ModifierVisitor<Void> {
     addedClasses = new HashSet<>();
   }
 
+  /** Cheap and dirty trick to avoid an infinite loop TODO: clean this up after the deadline */
+  private static HashSet<String> visitedBounds = new HashSet();
+
   @Override
   public Visitable visit(ClassOrInterfaceDeclaration decl, Void p) {
     if (usedClass.contains(decl.resolve().getQualifiedName())) {
@@ -64,8 +67,11 @@ public class InheritancePreserveVisitor extends ModifierVisitor<Void> {
         // preserve the bounds of the type parameters, too
         for (TypeParameter tp : decl.getTypeParameters()) {
           for (Type bound : tp.getTypeBound()) {
-            TargetMethodFinderVisitor.updateUsedClassWithQualifiedClassName(
-                bound.resolve().describe(), addedClasses, new HashMap<>());
+            String boundDesc = bound.resolve().describe();
+            if (visitedBounds.add(boundDesc)) {
+              TargetMethodFinderVisitor.updateUsedClassWithQualifiedClassName(
+                  boundDesc, addedClasses, new HashMap<>());
+            }
           }
         }
       }

--- a/src/main/java/org/checkerframework/specimin/InheritancePreserveVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/InheritancePreserveVisitor.java
@@ -3,6 +3,7 @@ package org.checkerframework.specimin;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
@@ -59,6 +60,15 @@ public class InheritancePreserveVisitor extends ModifierVisitor<Void> {
   @Override
   public Visitable visit(ClassOrInterfaceDeclaration decl, Void p) {
     if (usedClass.contains(decl.resolve().getQualifiedName())) {
+      if (decl.getTypeParameters().size() > 0) {
+        // preserve the bounds of the type parameters, too
+        for (TypeParameter tp : decl.getTypeParameters()) {
+          for (Type bound : tp.getTypeBound()) {
+            TargetMethodFinderVisitor.updateUsedClassWithQualifiedClassName(
+                bound.resolve().describe(), addedClasses, new HashMap<>());
+          }
+        }
+      }
       for (ClassOrInterfaceType extendedType : decl.getExtendedTypes()) {
         try {
           // Including a non-primary to primary map in this context may lead to an infinite loop,

--- a/src/main/resources/min_program_compile_status.json
+++ b/src/main/resources/min_program_compile_status.json
@@ -17,6 +17,5 @@
   "Issue689": "PASS",
   "cf-6388": "PASS",
   "cf-3025": "PASS",
-  "jdk-8319461": "PASS",
   "jdk-8288590": "PASS"
 }

--- a/src/main/resources/preservation_status.json
+++ b/src/main/resources/preservation_status.json
@@ -17,6 +17,6 @@
   "Issue689": "PASS",
   "cf-6388": "PASS",
   "cf-3025": "FAIL",
-  "jdk-8319461": "FAIL",
+  "jdk-8319461": "PASS",
   "jdk-8288590": "PASS"
 }

--- a/src/test/java/org/checkerframework/specimin/SuperinterfaceExtendsTest.java
+++ b/src/test/java/org/checkerframework/specimin/SuperinterfaceExtendsTest.java
@@ -1,0 +1,17 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * This test checks that we properly preserve superinterface bounds. Based on the bug JDK-8319461.
+ */
+public class SuperinterfaceExtendsTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "superinterfaceextends",
+        new String[] {"com/example/PropertyFactoryManager.java"},
+        new String[] {"com.example.PropertyFactoryManager#create(Class<P>, Class<V>)"});
+  }
+}

--- a/src/test/resources/abstractoverride2/expected/com/example/AbstractSimple.java
+++ b/src/test/resources/abstractoverride2/expected/com/example/AbstractSimple.java
@@ -1,0 +1,4 @@
+package com.example;
+
+interface AbstractSimple {
+}

--- a/src/test/resources/abstractoverride2/expected/com/example/Simple.java
+++ b/src/test/resources/abstractoverride2/expected/com/example/Simple.java
@@ -1,6 +1,6 @@
 package com.example;
 
-class Simple {
+class Simple implements AbstractSimple {
 
     void bar() {
     }

--- a/src/test/resources/implicitinterfaceaccesswithmanyinterfaces/expected/com/example/Simple.java
+++ b/src/test/resources/implicitinterfaceaccesswithmanyinterfaces/expected/com/example/Simple.java
@@ -1,8 +1,10 @@
 package com.example;
 
+import org.testing.B;
+import org.testing.C;
 import org.testing.D;
 
-abstract class Simple implements D {
+abstract class Simple implements B, C, D {
 
     int foo() {
         return baz();

--- a/src/test/resources/implicitinterfaceaccesswithmanyinterfaces/expected/org/testing/B.java
+++ b/src/test/resources/implicitinterfaceaccesswithmanyinterfaces/expected/org/testing/B.java
@@ -1,0 +1,4 @@
+package org.testing;
+
+public interface B {
+}

--- a/src/test/resources/implicitinterfaceaccesswithmanyinterfaces/expected/org/testing/C.java
+++ b/src/test/resources/implicitinterfaceaccesswithmanyinterfaces/expected/org/testing/C.java
@@ -1,0 +1,4 @@
+package org.testing;
+
+public interface C {
+}

--- a/src/test/resources/superinterfaceextends/expected/com/example/PropertyFactory.java
+++ b/src/test/resources/superinterfaceextends/expected/com/example/PropertyFactory.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public interface PropertyFactory<V, P extends WritableProperty<V>> {
+
+}

--- a/src/test/resources/superinterfaceextends/expected/com/example/PropertyFactoryManager.java
+++ b/src/test/resources/superinterfaceextends/expected/com/example/PropertyFactoryManager.java
@@ -1,0 +1,14 @@
+package com.example;
+
+public interface PropertyFactoryManager {
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    default <V, P extends ReadableProperty<V>> P create(Class<P> propertyType, Class<V> valueClass) {
+        PropertyFactory factory = getRequiredFactory(propertyType, valueClass);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    default <V, P extends ReadableProperty<V>> PropertyFactory<V, ? extends P> getRequiredFactory(Class<P> propertyType, Class<V> valueType) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/superinterfaceextends/expected/com/example/ReadableProperty.java
+++ b/src/test/resources/superinterfaceextends/expected/com/example/ReadableProperty.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public interface ReadableProperty<V> {
+
+}

--- a/src/test/resources/superinterfaceextends/expected/com/example/WritableProperty.java
+++ b/src/test/resources/superinterfaceextends/expected/com/example/WritableProperty.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public interface WritableProperty<V> extends ReadableProperty<V> {
+
+}

--- a/src/test/resources/superinterfaceextends/input/com/example/PropertyFactory.java
+++ b/src/test/resources/superinterfaceextends/input/com/example/PropertyFactory.java
@@ -1,0 +1,8 @@
+package com.example;
+
+
+public interface PropertyFactory<V, P extends WritableProperty<V>> {
+    default P create(String name, PropertyTypeInfo<V> valueClass, PropertyMetadata<V> metadata) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/superinterfaceextends/input/com/example/PropertyFactoryManager.java
+++ b/src/test/resources/superinterfaceextends/input/com/example/PropertyFactoryManager.java
@@ -1,0 +1,15 @@
+package com.example;
+
+public interface PropertyFactoryManager {
+
+    // target method
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    default <V, P extends ReadableProperty<V>> P create(Class<P> propertyType, Class<V> valueClass) {
+        PropertyFactory factory = getRequiredFactory(propertyType, valueClass);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    default <V, P extends ReadableProperty<V>> PropertyFactory<V, ? extends P> getRequiredFactory(Class<P> propertyType, Class<V> valueType) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/superinterfaceextends/input/com/example/ReadableProperty.java
+++ b/src/test/resources/superinterfaceextends/input/com/example/ReadableProperty.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public interface ReadableProperty<V> {
+
+}

--- a/src/test/resources/superinterfaceextends/input/com/example/WritableProperty.java
+++ b/src/test/resources/superinterfaceextends/input/com/example/WritableProperty.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public interface WritableProperty<V> extends ReadableProperty<V> {
+
+}

--- a/src/test/resources/unsolvedinterface/expected/com/example/Foo.java
+++ b/src/test/resources/unsolvedinterface/expected/com/example/Foo.java
@@ -1,6 +1,8 @@
 package com.example;
 
-class Foo {
+import org.testing.Baz;
+
+class Foo implements Baz {
 
     public void doManyThing() {
         System.out.println("Foo is doing many things!");

--- a/src/test/resources/unsolvedinterface/expected/org/testing/Baz.java
+++ b/src/test/resources/unsolvedinterface/expected/org/testing/Baz.java
@@ -1,0 +1,4 @@
+package org.testing;
+
+public interface Baz {
+}

--- a/src/test/resources/unusedinterface/expected/com/example/Baz.java
+++ b/src/test/resources/unusedinterface/expected/com/example/Baz.java
@@ -1,0 +1,5 @@
+package com.example;
+
+// Baz.java
+public interface Baz {
+}

--- a/src/test/resources/unusedinterface/expected/com/example/Foo.java
+++ b/src/test/resources/unusedinterface/expected/com/example/Foo.java
@@ -1,6 +1,6 @@
 package com.example;
 
-class Foo {
+class Foo implements Baz {
 
     public void doManyThing() {
         System.out.println("Foo is doing many things!");

--- a/src/test/resources/unusedtypeparameterbound/expected/com/example/Simple.java
+++ b/src/test/resources/unusedtypeparameterbound/expected/com/example/Simple.java
@@ -1,8 +1,9 @@
 package com.example;
 
 import org.testing.Baz;
+import org.testing.Foo;
 
-class Simple<T extends Baz, V> {
+class Simple<T extends Baz, V extends Foo> {
 
     void bar(T bazObject) {
         bazObject.bazMethod();

--- a/src/test/resources/unusedtypeparameterbound/expected/org/testing/Foo.java
+++ b/src/test/resources/unusedtypeparameterbound/expected/org/testing/Foo.java
@@ -1,0 +1,5 @@
+package org.testing;
+
+public class Foo {
+    // No methods are used in Simple class, but this should still be preserved!
+}

--- a/src/test/resources/unusedtypeparameterbound/input/org/testing/Foo.java
+++ b/src/test/resources/unusedtypeparameterbound/input/org/testing/Foo.java
@@ -1,5 +1,5 @@
 package org.testing;
 
 public class Foo {
-    // No methods are used in Simple class
+    // No methods are used in Simple class, but this should still be preserved!
 }

--- a/typecheck_test_outputs.sh
+++ b/typecheck_test_outputs.sh
@@ -12,6 +12,8 @@ returnval=0
 cd src/test/resources || exit 1
 for testcase in * ; do
     if [ "${testcase}" = "shared" ]; then continue; fi
+    # https://bugs.openjdk.org/browse/JDK-8319461 wasn't actually fixed (this test is based on that bug)
+    if [ "${testcase}" = "superinterfaceextends" ]; then continue; fi
     cd "${testcase}/expected/" || exit 1
     # javac relies on word splitting
     # shellcheck disable=SC2046


### PR DESCRIPTION
This should be part of the modularity model. The previous test case that showed we didn't do this was wrong, and I should not have approved it.

Should fix JDK-8319461.