### PR TITLE
Update JavaParser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ application {
 
 dependencies {
 
-    implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.23.1'
+    implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.25.10'
 
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
 

--- a/src/main/java/org/checkerframework/specimin/GetTypesFullNameVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/GetTypesFullNameVisitor.java
@@ -64,15 +64,8 @@ public class GetTypesFullNameVisitor extends ModifierVisitor<Void> {
   public Visitable visit(ClassOrInterfaceType type, Void p) {
     String typeFullName;
     try {
-      /*
-       * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
-       * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
-       * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
-       * This appears to be an inaccuracy within JavaParser's type hierarchy.
-       */
-
-      // since type is a ClassOrInterfaceType instance, it is safe to cast it to a ReferenceType.
-      typeFullName = type.resolve().asReferenceType().getQualifiedName();
+      typeFullName =
+          JavaParserUtil.classOrInterfaceTypeToResolvedReferenceType(type).getQualifiedName();
     } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
       return super.visit(type, p);
     }

--- a/src/main/java/org/checkerframework/specimin/GetTypesFullNameVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/GetTypesFullNameVisitor.java
@@ -64,7 +64,8 @@ public class GetTypesFullNameVisitor extends ModifierVisitor<Void> {
   public Visitable visit(ClassOrInterfaceType type, Void p) {
     String typeFullName;
     try {
-      typeFullName = type.resolve().getQualifiedName();
+      // since type is a ClassOrInterfaceType instance, it is safe to cast it to a ReferenceType.
+      typeFullName = type.resolve().asReferenceType().getQualifiedName();
     } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
       return super.visit(type, p);
     }

--- a/src/main/java/org/checkerframework/specimin/GetTypesFullNameVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/GetTypesFullNameVisitor.java
@@ -64,6 +64,13 @@ public class GetTypesFullNameVisitor extends ModifierVisitor<Void> {
   public Visitable visit(ClassOrInterfaceType type, Void p) {
     String typeFullName;
     try {
+      /*
+       * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
+       * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
+       * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
+       * This appears to be an inaccuracy within JavaParser's type hierarchy.
+       */
+
       // since type is a ClassOrInterfaceType instance, it is safe to cast it to a ReferenceType.
       typeFullName = type.resolve().asReferenceType().getQualifiedName();
     } catch (UnsolvedSymbolException | UnsupportedOperationException e) {

--- a/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
+++ b/src/main/java/org/checkerframework/specimin/JavaParserUtil.java
@@ -2,6 +2,8 @@ package org.checkerframework.specimin;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
 
 /**
  * A class containing useful static functions using JavaParser.
@@ -45,5 +47,25 @@ public class JavaParserUtil {
   public static boolean isLocalClassDecl(TypeDeclaration<?> decl) {
     return decl.isClassOrInterfaceDeclaration()
         && decl.asClassOrInterfaceDeclaration().isLocalClassDeclaration();
+  }
+
+  /**
+   * Given a ClassOrInterfaceType instance, this method returns a corresponding
+   * ResolvedReferenceType. This method might throw an exception if the given instance is
+   * unresolved.
+   *
+   * <p>Note: In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType (check an example
+   * here:
+   * https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
+   * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a
+   * specific ResolvedReferenceType. This appears to be an inaccuracy within JavaParser's type
+   * hierarchy.
+   *
+   * @param type the ClassOrInterfaceType instance
+   * @return the corresponding ResolvedReferenceType instance
+   */
+  public static ResolvedReferenceType classOrInterfaceTypeToResolvedReferenceType(
+      ClassOrInterfaceType type) {
+    return type.resolve().asReferenceType();
   }
 }

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -192,16 +192,8 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
     for (ClassOrInterfaceType implementedType : implementedTypes) {
       ResolvedReferenceType resolvedInterface;
       try {
-        /*
-         * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
-         * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
-         * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
-         * This appears to be an inaccuracy within JavaParser's type hierarchy.
-         */
-
-        // since implementedType is a ClassOrInterfaceType instance, it is safe to cast it to a
-        // ReferenceType.
-        resolvedInterface = implementedType.resolve().asReferenceType();
+        resolvedInterface =
+            JavaParserUtil.classOrInterfaceTypeToResolvedReferenceType(implementedType);
       } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
         // In this case, we're implementing an interface that we don't control
         // or that will not be preserved.

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -192,7 +192,9 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
     for (ClassOrInterfaceType implementedType : implementedTypes) {
       ResolvedReferenceType resolvedInterface;
       try {
-        resolvedInterface = implementedType.resolve();
+        // since implementedType is a ClassOrInterfaceType instance, it is safe to cast it to a
+        // ReferenceType.
+        resolvedInterface = implementedType.resolve().asReferenceType();
       } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
         // In this case, we're implementing an interface that we don't control
         // or that will not be preserved.

--- a/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/MustImplementMethodsVisitor.java
@@ -192,6 +192,13 @@ public class MustImplementMethodsVisitor extends ModifierVisitor<Void> {
     for (ClassOrInterfaceType implementedType : implementedTypes) {
       ResolvedReferenceType resolvedInterface;
       try {
+        /*
+         * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
+         * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
+         * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
+         * This appears to be an inaccuracy within JavaParser's type hierarchy.
+         */
+
         // since implementedType is a ClassOrInterfaceType instance, it is safe to cast it to a
         // ReferenceType.
         resolvedInterface = implementedType.resolve().asReferenceType();

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -222,16 +222,9 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
     while (iterator.hasNext()) {
       ClassOrInterfaceType interfaceType = iterator.next();
       try {
-        /*
-         * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
-         * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
-         * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
-         * This appears to be an inaccuracy within JavaParser's type hierarchy.
-         */
-
-        // since interfaceType is a ClassOrInterfaceType instance, it is safe to cast it to a
-        // ReferenceType.
-        String typeFullName = interfaceType.resolve().asReferenceType().getQualifiedName();
+        String typeFullName =
+            JavaParserUtil.classOrInterfaceTypeToResolvedReferenceType(interfaceType)
+                .getQualifiedName();
         if (!classesUsedByTargetMethods.contains(typeFullName)) {
           iterator.remove();
         }

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -222,6 +222,13 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
     while (iterator.hasNext()) {
       ClassOrInterfaceType interfaceType = iterator.next();
       try {
+        /*
+         * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
+         * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
+         * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
+         * This appears to be an inaccuracy within JavaParser's type hierarchy.
+         */
+
         // since interfaceType is a ClassOrInterfaceType instance, it is safe to cast it to a
         // ReferenceType.
         String typeFullName = interfaceType.resolve().asReferenceType().getQualifiedName();

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -222,7 +222,9 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
     while (iterator.hasNext()) {
       ClassOrInterfaceType interfaceType = iterator.next();
       try {
-        String typeFullName = interfaceType.resolve().getQualifiedName();
+        // since interfaceType is a ClassOrInterfaceType instance, it is safe to cast it to a
+        // ReferenceType.
+        String typeFullName = interfaceType.resolve().asReferenceType().getQualifiedName();
         if (!classesUsedByTargetMethods.contains(typeFullName)) {
           iterator.remove();
         }

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -432,7 +432,7 @@ public class SpeciminRunner {
       // Write the string representation of CompilationUnit to the file
       try {
         PrintWriter writer = new PrintWriter(targetOutputPath.toFile(), StandardCharsets.UTF_8);
-        writer.print(target.getValue());
+        writer.print(getCompilationUnitWithCommentsTrimmed(target.getValue()));
         writer.close();
       } catch (IOException e) {
         System.out.println("failed to write output file " + targetOutputPath);
@@ -594,6 +594,20 @@ public class SpeciminRunner {
         throw new RuntimeException("Unresolved file path: " + filePath);
       }
     }
+  }
+
+  /**
+   * Returns a comment-free version of a compilation unit.
+   *
+   * @param cu A compilation unit possibly containing comments.
+   * @return A comment-free version of the compilation unit.
+   */
+  private static CompilationUnit getCompilationUnitWithCommentsTrimmed(CompilationUnit cu) {
+    CompilationUnit cuWithNoComments = cu;
+    for (Comment child : cuWithNoComments.getAllComments()) {
+      child.remove();
+    }
+    return cuWithNoComments;
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -263,6 +263,13 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   public Visitable visit(ClassOrInterfaceDeclaration decl, Void p) {
     for (ClassOrInterfaceType interfaceType : decl.getImplementedTypes()) {
       try {
+        /*
+         * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
+         * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
+         * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
+         * This appears to be an inaccuracy within JavaParser's type hierarchy.
+         */
+
         // since interfaceType is a ClassOrInterfaceType instance, it is safe to cast it to a
         // ReferenceType.
         updateMethodDeclarationToInterfaceType(

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -585,6 +585,13 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
       return super.visit(type, p);
     }
     try {
+      /*
+       * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
+       * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
+       * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
+       * This appears to be an inaccuracy within JavaParser's type hierarchy.
+       */
+
       // since type is a ClassOrInterfaceType instance, it is safe to cast it to a ReferenceType.
       ResolvedReferenceType typeResolved = type.resolve().asReferenceType();
       updateUsedClassBasedOnType(typeResolved);
@@ -708,6 +715,13 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
               .describe()
               .equals(interfaceMethod.getReturnType().describe())) {
             if (method.getNumberOfParams() == interfaceMethod.getNumberOfParams()) {
+              /*
+               * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
+               * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
+               * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
+               * This appears to be an inaccuracy within JavaParser's type hierarchy.
+               */
+
               // since methodDeclarationToInterfaceType.get(interfaceMethod) is a
               // ClassOrInterfaceType instance, it is safe to cast it to a ReferenceType.
               updateUsedClassWithQualifiedClassName(

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -263,8 +263,10 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
   public Visitable visit(ClassOrInterfaceDeclaration decl, Void p) {
     for (ClassOrInterfaceType interfaceType : decl.getImplementedTypes()) {
       try {
+        // since interfaceType is a ClassOrInterfaceType instance, it is safe to cast it to a
+        // ReferenceType.
         updateMethodDeclarationToInterfaceType(
-            interfaceType.resolve().getAllMethods(), interfaceType);
+            interfaceType.resolve().asReferenceType().getAllMethods(), interfaceType);
       } catch (UnsolvedSymbolException e) {
         continue;
       }
@@ -583,7 +585,8 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
       return super.visit(type, p);
     }
     try {
-      ResolvedReferenceType typeResolved = type.resolve();
+      // since type is a ClassOrInterfaceType instance, it is safe to cast it to a ReferenceType.
+      ResolvedReferenceType typeResolved = type.resolve().asReferenceType();
       updateUsedClassBasedOnType(typeResolved);
     }
     // if the type has a fully-qualified form, JavaParser also consider other components rather than
@@ -705,10 +708,13 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
               .describe()
               .equals(interfaceMethod.getReturnType().describe())) {
             if (method.getNumberOfParams() == interfaceMethod.getNumberOfParams()) {
+              // since methodDeclarationToInterfaceType.get(interfaceMethod) is a
+              // ClassOrInterfaceType instance, it is safe to cast it to a ReferenceType.
               updateUsedClassWithQualifiedClassName(
                   methodDeclarationToInterfaceType
                       .get(interfaceMethod)
                       .resolve()
+                      .asReferenceType()
                       .getQualifiedName(),
                   usedTypeElement,
                   nonPrimaryClassesToPrimaryClass);

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1093,18 +1093,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       return super.visit(typeExpr, p);
     }
     try {
-      /*
-       * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
-       * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
-       * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
-       * This appears to be an inaccuracy within JavaParser's type hierarchy.
-       */
-
-      // since typeExpr is a ClassOrInterfaceType, it is safe to cast the resolved result to
-      // ReferenceType.
       // resolve() checks whether this type is resolved. getAllAncestor() checks whether this type
       // extends or implements a resolved class/interface.
-      typeExpr.resolve().asReferenceType().getAllAncestors();
+      JavaParserUtil.classOrInterfaceTypeToResolvedReferenceType(typeExpr).getAllAncestors();
       return super.visit(typeExpr, p);
     }
     /*
@@ -1509,16 +1500,10 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
 
     ResolvedReferenceType resolvedClass;
     try {
-      /*
-       * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
-       * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
-       * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
-       * This appears to be an inaccuracy within JavaParser's type hierarchy.
-       */
-
       // since resolvedClass is a ClassOrInterfaceType instance, it is safe to cast it to a
       // ReferenceType.
-      resolvedClass = classOrInterfaceType.resolve().asReferenceType();
+      resolvedClass =
+          JavaParserUtil.classOrInterfaceTypeToResolvedReferenceType(classOrInterfaceType);
       if (!resolvedClass.getAllAncestors().isEmpty()) {
         String pathOfThisCurrentType = qualifiedNameToFilePath(fullyQualifiedName);
         if (!addedTargetFiles.contains(pathOfThisCurrentType)) {
@@ -2480,22 +2465,10 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       String typeSimpleName = callerExpression.asTypeVariable().describe();
       for (Map<String, NodeList<ClassOrInterfaceType>> typeScope : typeVariables) {
         if (typeScope.containsKey(typeSimpleName)) {
-          /*
-           * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
-           * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
-           * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
-           * This appears to be an inaccuracy within JavaParser's type hierarchy.
-           */
-
-          // since typeScope.get(typeSimpleName).get(0) is a ClassOrInterfaceType instance, it is
-          // safe to cast it to a ReferenceType.
           // a type parameter can extend a class and many interfaces. However, the class will always
           // be listed first.
-          return typeScope
-              .get(typeSimpleName)
-              .get(0)
-              .resolve()
-              .asReferenceType()
+          return JavaParserUtil.classOrInterfaceTypeToResolvedReferenceType(
+                  typeScope.get(typeSimpleName).get(0))
               .getQualifiedName();
         }
       }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1092,9 +1092,11 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       return super.visit(typeExpr, p);
     }
     try {
+      // since typeExpr is a ClassOrInterfaceType, it is safe to cast the resolved result to
+      // ReferenceType.
       // resolve() checks whether this type is resolved. getAllAncestor() checks whether this type
       // extends or implements a resolved class/interface.
-      typeExpr.resolve().getAllAncestors();
+      typeExpr.resolve().asReferenceType().getAllAncestors();
       return super.visit(typeExpr, p);
     }
     /*
@@ -1499,7 +1501,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
 
     ResolvedReferenceType resolvedClass;
     try {
-      resolvedClass = classOrInterfaceType.resolve();
+      // since resolvedClass is a ClassOrInterfaceType instance, it is safe to cast it to a
+      // ReferenceType.
+      resolvedClass = classOrInterfaceType.resolve().asReferenceType();
       if (!resolvedClass.getAllAncestors().isEmpty()) {
         String pathOfThisCurrentType = qualifiedNameToFilePath(fullyQualifiedName);
         if (!addedTargetFiles.contains(pathOfThisCurrentType)) {
@@ -2207,7 +2211,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       // for reference type, we need the fully-qualified name to avoid having to add additional
       // import statements.
       if (type.isReferenceType()) {
-        ResolvedReferenceType rrType = (ResolvedReferenceType) type;
+        ResolvedReferenceType rrType = type.asReferenceType();
         // avoid creating methods with raw parameter types
         int ctypevar = rrType.getTypeParametersMap().size();
         String typevars = "";
@@ -2370,6 +2374,23 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    * @return true if the expression can be solved
    */
   public static boolean canBeSolved(Expression expr) {
+
+    // The method calculateResolvedType() gets lazy and lacks precision when it comes to handling
+    // ObjectCreationExpr instances, thus requiring separate treatment for ObjectCreationExpr.
+
+    // Note: JavaParser's lazy approach to ObjectCreationExpr when it comes to
+    // calculateResolvedType() is reasonable, as the return type typically corresponds to the class
+    // itself. Consequently, JavaParser does not actively search for constructor declarations within
+    // the class. While this approach suffices for compilable input, it is inadequate for handling
+    // incomplete synthetic classes, such as in our case.
+    if (expr instanceof ObjectCreationExpr) {
+      try {
+        expr.asObjectCreationExpr().resolve();
+        return true;
+      } catch (UnsolvedSymbolException | UnsupportedOperationException e) {
+        return false;
+      }
+    }
     try {
       ResolvedType resolvedType = expr.calculateResolvedType();
       if (resolvedType.isTypeVariable()) {
@@ -2444,9 +2465,16 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       String typeSimpleName = callerExpression.asTypeVariable().describe();
       for (Map<String, NodeList<ClassOrInterfaceType>> typeScope : typeVariables) {
         if (typeScope.containsKey(typeSimpleName)) {
+          // since typeScope.get(typeSimpleName).get(0) is a ClassOrInterfaceType instance, it is
+          // safe to cast it to a ReferenceType.
           // a type parameter can extend a class and many interfaces. However, the class will always
           // be listed first.
-          return typeScope.get(typeSimpleName).get(0).resolve().getQualifiedName();
+          return typeScope
+              .get(typeSimpleName)
+              .get(0)
+              .resolve()
+              .asReferenceType()
+              .getQualifiedName();
         }
       }
     }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1093,6 +1093,13 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       return super.visit(typeExpr, p);
     }
     try {
+      /*
+       * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
+       * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
+       * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
+       * This appears to be an inaccuracy within JavaParser's type hierarchy.
+       */
+
       // since typeExpr is a ClassOrInterfaceType, it is safe to cast the resolved result to
       // ReferenceType.
       // resolve() checks whether this type is resolved. getAllAncestor() checks whether this type

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1502,6 +1502,13 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
 
     ResolvedReferenceType resolvedClass;
     try {
+      /*
+       * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
+       * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
+       * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
+       * This appears to be an inaccuracy within JavaParser's type hierarchy.
+       */
+
       // since resolvedClass is a ClassOrInterfaceType instance, it is safe to cast it to a
       // ReferenceType.
       resolvedClass = classOrInterfaceType.resolve().asReferenceType();
@@ -2466,6 +2473,13 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
       String typeSimpleName = callerExpression.asTypeVariable().describe();
       for (Map<String, NodeList<ClassOrInterfaceType>> typeScope : typeVariables) {
         if (typeScope.containsKey(typeSimpleName)) {
+          /*
+           * In JavaParser, ClassOrInterfaceType is a subtype of ReferenceType
+           * (check an example here: https://github.com/javaparser/javaparser/blob/9c133d19d5b85b3b758f05762fb4d7c9875ef681/javaparser-core/src/main/java/com/github/javaparser/ast/type/ClassOrInterfaceType.java#L258).
+           * However, the resolve() method in ClassOrInterfaceType only returns a ResolvedType instead of a specific ResolvedReferenceType.
+           * This appears to be an inaccuracy within JavaParser's type hierarchy.
+           */
+
           // since typeScope.get(typeSimpleName).get(0) is a ClassOrInterfaceType instance, it is
           // safe to cast it to a ReferenceType.
           // a type parameter can extend a class and many interfaces. However, the class will always

--- a/src/test/resources/interfacereappearance/expected/com/example/Baz.java
+++ b/src/test/resources/interfacereappearance/expected/com/example/Baz.java
@@ -1,5 +1,4 @@
 package com.example;
 
-// This kind of declaration will confuse InheritancePreserveVisitor, making it adding Baz to the list of added classes again, which will lead to a possible infinite loop.
 public interface Baz extends Comparable<Baz> {
 }

--- a/src/test/resources/navigablesetexample/expected/com/example/Simple.java
+++ b/src/test/resources/navigablesetexample/expected/com/example/Simple.java
@@ -1,6 +1,3 @@
-/*
- * Based on an example from java.util.Collections.
- */
 package com.example;
 
 public class Simple {

--- a/src/test/resources/navigablesetexample2/expected/com/example/Simple.java
+++ b/src/test/resources/navigablesetexample2/expected/com/example/Simple.java
@@ -1,8 +1,5 @@
 package com.example;
 
-/*
- * Based on an example from java.util.Collections.
- */
 public class Simple {
 
     static class UnmodifiableCollection<E> {

--- a/src/test/resources/navigablesetfieldexample/expected/com/example/Simple.java
+++ b/src/test/resources/navigablesetfieldexample/expected/com/example/Simple.java
@@ -1,6 +1,3 @@
-/*
- * Based on an example from java.util.Collections.
- */
 package com.example;
 
 public class Simple {

--- a/src/test/resources/twofilesimple/input/com/example/Simple.java
+++ b/src/test/resources/twofilesimple/input/com/example/Simple.java
@@ -1,0 +1,8 @@
+package com.example;
+
+class Simple {
+    // Target method.
+    public static void bar() {
+        Foo[] foos = Foo.getFoos();
+    }
+}

--- a/src/test/resources/twofilesimple/input/com/example/Simple.java
+++ b/src/test/resources/twofilesimple/input/com/example/Simple.java
@@ -1,8 +1,0 @@
-package com.example;
-
-class Simple {
-    // Target method.
-    public static void bar() {
-        Foo[] foos = Foo.getFoos();
-    }
-}

--- a/src/test/resources/typevar-collision/expected/com/T.java
+++ b/src/test/resources/typevar-collision/expected/com/T.java
@@ -1,0 +1,4 @@
+package com;
+
+public class T {
+}

--- a/src/test/resources/typevar-collision/expected/org/Foo.java
+++ b/src/test/resources/typevar-collision/expected/org/Foo.java
@@ -1,6 +1,9 @@
 package org;
 
+import com.T;
+
 public class Foo<T> {
+
     T useT(T t) {
         return t;
     }

--- a/src/test/resources/typevar-collision/input/org/Foo.java
+++ b/src/test/resources/typevar-collision/input/org/Foo.java
@@ -1,6 +1,6 @@
 package org;
 
-// This import isn't used.
+// This import isn't used. But JavaParser is imprecise, hence com/T.java will still be included in the final output.
 import com.T;
 
 public class Foo<T> {

--- a/src/test/resources/unusedinterface/expected/com/example/Baz.java
+++ b/src/test/resources/unusedinterface/expected/com/example/Baz.java
@@ -1,5 +1,4 @@
 package com.example;
 
-// Baz.java
 public interface Baz {
 }

--- a/src/test/resources/unusedtypeparameterbound/expected/org/testing/Foo.java
+++ b/src/test/resources/unusedtypeparameterbound/expected/org/testing/Foo.java
@@ -1,5 +1,5 @@
 package org.testing;
 
 public class Foo {
-    // No methods are used in Simple class, but this should still be preserved!
+
 }


### PR DESCRIPTION
Professor,

This is the PR to use the newest version of JavaParser.

The type variables collision test is failing. Here is the input file:

```java
package org;

// This import isn't used.
import com.T;

public class Foo<T> {
    T useT(T t) {
        return t;
    }
}
```
It turns out that this new version of JavaParser confuses the `T` in `useT` to be `com.T`. I don't think this is a serious bug, since we will only end up with an extra file in the final output of Specimin. I am thinking of removing the type variables collision test since the new version of JavaParser can not discern those collisions properly anymore. Let me know what you think.