### PR TITLE
Test for unary expressions

### DIFF
--- a/src/test/java/org/checkerframework/specimin/UnaryExprTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnaryExprTest.java
@@ -1,8 +1,7 @@
 package org.checkerframework.specimin;
 
-import org.junit.Test;
-
 import java.io.IOException;
+import org.junit.Test;
 
 /** This test checks that arguments to unary expressions have appropriate types. */
 public class UnaryExprTest {

--- a/src/test/java/org/checkerframework/specimin/UnaryExprTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnaryExprTest.java
@@ -1,0 +1,16 @@
+package org.checkerframework.specimin;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/** This test checks that arguments to unary expressions have appropriate types. */
+public class UnaryExprTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unaryexpr",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#test(Foo)"});
+  }
+}

--- a/src/test/resources/unaryexpr/expected/com/example/Foo.java
+++ b/src/test/resources/unaryexpr/expected/com/example/Foo.java
@@ -1,0 +1,16 @@
+package com.example;
+
+public class Foo {
+
+    public int bar;
+
+    public long qux;
+
+    public int baz() {
+        throw new Error();
+    }
+
+    public double razz() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/unaryexpr/expected/com/example/Simple.java
+++ b/src/test/resources/unaryexpr/expected/com/example/Simple.java
@@ -1,0 +1,18 @@
+package com.example;
+
+class Simple {
+
+    void test(Foo f) {
+
+        f.bar += 5;
+
+        int y = 4;
+        y += f.baz();
+
+        long w = 1000000L;
+        w -= f.qux;
+
+        double d = 5.42;
+        d *= f.razz();
+    }
+}

--- a/src/test/resources/unaryexpr/input/com/example/Simple.java
+++ b/src/test/resources/unaryexpr/input/com/example/Simple.java
@@ -1,0 +1,18 @@
+package com.example;
+
+class Simple {
+
+    void test(Foo f) {
+
+        f.bar += 5;
+
+        int y = 4;
+        y += f.baz();
+
+        long w = 1000000L;
+        w -= f.qux;
+
+        double d = 5.42;
+        d *= f.razz();
+    }
+}


### PR DESCRIPTION
Based on the bug that was fixed by #262, I was concerned that our handling of unary expressions might also be incorrect. I checked for a test case, and found that we didn't have one (because we didn't have a test containing the string `+=`), so I wrote the one in this PR. To my pleasant surprise, the test passes - I think our usual type correct algorithm actually handles this case just fine, since there is no special error message for mistakes in unary operator types (as there is for binary operators).