### PR TITLE
Don't lose information in synthetic types when correcting their type via JavaTypeCorrect

### DIFF
--- a/src/test/java/org/checkerframework/specimin/UnsolvedMethodTypeCorrectTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnsolvedMethodTypeCorrectTest.java
@@ -1,12 +1,11 @@
 package org.checkerframework.specimin;
 
+import java.io.IOException;
 import org.junit.Test;
 
-import java.io.IOException;
-
 /**
- * This test checks that interaction between JavaTypeCorrect and adding unsolved
- * methods to unsolved classes doesn't cause a method to be lost. Based on a historic bug.
+ * This test checks that interaction between JavaTypeCorrect and adding unsolved methods to unsolved
+ * classes doesn't cause a method to be lost. Based on a historic bug.
  */
 public class UnsolvedMethodTypeCorrectTest {
   @Test

--- a/src/test/java/org/checkerframework/specimin/UnsolvedMethodTypeCorrectTest.java
+++ b/src/test/java/org/checkerframework/specimin/UnsolvedMethodTypeCorrectTest.java
@@ -1,0 +1,19 @@
+package org.checkerframework.specimin;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * This test checks that interaction between JavaTypeCorrect and adding unsolved
+ * methods to unsolved classes doesn't cause a method to be lost. Based on a historic bug.
+ */
+public class UnsolvedMethodTypeCorrectTest {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "unsolvedmethodtypecorrect",
+        new String[] {"com/example/Simple.java"},
+        new String[] {"com.example.Simple#bar()"});
+  }
+}

--- a/src/test/resources/unsolvedmethodtypecorrect/expected/com/example/Simple.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/expected/com/example/Simple.java
@@ -1,0 +1,8 @@
+package com.example;
+
+class Simple {
+    void bar() {
+        Foo f = new Foo();
+        f.getLocals().set(0);
+    }
+}

--- a/src/test/resources/unsolvedmethodtypecorrect/expected/com/example/Simple.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/expected/com/example/Simple.java
@@ -1,8 +1,16 @@
 package com.example;
 
+import org.example.LocalVariables;
+import org.example.Foo;
+
 class Simple {
     void bar() {
         Foo f = new Foo();
         f.getLocals().set(0);
+        baz();
+    }
+
+    void baz() {
+        throw new Error();
     }
 }

--- a/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/Foo.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/Foo.java
@@ -1,0 +1,12 @@
+package org.example;
+
+public class Foo {
+
+    public Foo() {
+        throw new Error();
+    }
+
+    public org.example.LocalVariables getLocals() {
+        throw new Error();
+    }
+}

--- a/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/LocalVariables.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/LocalVariables.java
@@ -2,7 +2,7 @@ package org.example;
 
 public class LocalVariables {
 
-    SetReturnType set(int parameter0) {
+    public SetReturnType set(int parameter0) {
         throw new Error();
     }
 }

--- a/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/LocalVariables.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/LocalVariables.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class LocalVariables {
+
+    SetReturnType set(int parameter0) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/SetReturnType.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/expected/org/example/SetReturnType.java
@@ -1,0 +1,4 @@
+package org.example;
+
+public class SetReturnType {
+}

--- a/src/test/resources/unsolvedmethodtypecorrect/input/com/example/Simple.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/input/com/example/Simple.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import org.example.LocalVariables;
+
+class Simple {
+    // Target method.
+    void bar() {
+        Foo f = new Foo();
+        f.getLocals().set(0);
+    }
+
+    void baz(Foo f) {
+        // To trigger JavaTypeCorrect.
+        LocalVariables locals = f.getLocals();
+    }
+}

--- a/src/test/resources/unsolvedmethodtypecorrect/input/com/example/Simple.java
+++ b/src/test/resources/unsolvedmethodtypecorrect/input/com/example/Simple.java
@@ -1,16 +1,19 @@
 package com.example;
 
 import org.example.LocalVariables;
+import org.example.Foo;
 
 class Simple {
     // Target method.
     void bar() {
         Foo f = new Foo();
         f.getLocals().set(0);
+        baz();
     }
 
-    void baz(Foo f) {
+    void baz() {
         // To trigger JavaTypeCorrect.
-        LocalVariables locals = f.getLocals();
+        Foo f = new Foo();
+        final LocalVariables locals = f.getLocals();
     }
 }


### PR DESCRIPTION
Also incidentally cleaned up some ISSTA tech debt that happened to get in the way.