### PR TITLE
Delete all synthetic files, even in the event of a crash, SIGINT, or SIGTERM

### DIFF
--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -111,21 +111,26 @@ public class SpeciminRunner {
       String outputDirectory)
       throws IOException {
     // The set of path of files that have been created by Specimin. We must be careful to delete all
-    // those
-    // files in the end, because otherwise they can pollute the input directory.
+    // those files in the end, because otherwise they can pollute the input directory. To do that,
+    // we need to register a shutdown hook with the JVM.
     Set<Path> createdClass = new HashSet<>();
-    try {
-      performMinimizationImpl(
-          root,
-          targetFiles,
-          jarPaths,
-          targetMethodNames,
-          targetFieldNames,
-          outputDirectory,
-          createdClass);
-    } finally {
-      deleteFiles(createdClass);
-    }
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread() {
+              @Override
+              public void run() {
+                deleteFiles(createdClass);
+              }
+            });
+
+    performMinimizationImpl(
+        root,
+        targetFiles,
+        jarPaths,
+        targetMethodNames,
+        targetFieldNames,
+        outputDirectory,
+        createdClass);
   }
 
   /**

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -110,7 +110,46 @@ public class SpeciminRunner {
       List<String> targetFieldNames,
       String outputDirectory)
       throws IOException {
+    // The set of path of files that have been created by Specimin. We must be careful to delete all
+    // those
+    // files in the end, because otherwise they can pollute the input directory.
+    Set<Path> createdClass = new HashSet<>();
+    try {
+      performMinimizationImpl(
+          root,
+          targetFiles,
+          jarPaths,
+          targetMethodNames,
+          targetFieldNames,
+          outputDirectory,
+          createdClass);
+    } finally {
+      deleteFiles(createdClass);
+    }
+  }
 
+  /**
+   * Helper method for performMinimization. The logic of performMinimization is here;
+   * performMinimization itself wraps this in a try-finally to ensure that all created files are
+   * cleaned up properly in the event of a crash or interrupt.
+   *
+   * @param root The root directory of the input files.
+   * @param targetFiles A list of files that contain the target methods.
+   * @param jarPaths Paths to relevant JAR files.
+   * @param targetMethodNames A set of target method names to be preserved.
+   * @param targetFieldNames A set of target field names to be preserved.
+   * @param outputDirectory The directory for the output.
+   * @throws IOException if there is an exception
+   */
+  private static void performMinimizationImpl(
+      String root,
+      List<String> targetFiles,
+      List<String> jarPaths,
+      List<String> targetMethodNames,
+      List<String> targetFieldNames,
+      String outputDirectory,
+      Set<Path> createdClass)
+      throws IOException {
     // To facilitate string manipulation in subsequent methods, ensure that 'root' ends with a
     // trailing slash.
     if (!root.endsWith("/")) {
@@ -177,9 +216,6 @@ public class SpeciminRunner {
             root, existingClassesToFilePath, targetMethodNames, targetFieldNames);
     addMissingClass.setClassesFromJar(jarPaths);
 
-    // The set of path of files that have been created by addMissingClass. We will delete all those
-    // files in the end.
-    Set<Path> createdClass = new HashSet<>();
     Map<String, String> typesToChange = new HashMap<>();
     Map<String, String> classAndUnresolvedInterface = new HashMap<>();
     while (addMissingClass.gettingException()) {
@@ -440,8 +476,6 @@ public class SpeciminRunner {
       }
     }
     createdClass.addAll(getPathsFromJarPaths(root, jarPaths));
-    // delete all the temporary files created by UnsolvedSymbolVisitor and VineFlower.
-    deleteFiles(createdClass);
   }
 
   /**


### PR DESCRIPTION
While debugging the infinite loop in #272, I got frustrated by the number of temporary files that I was cleaning up manually, and decided to take a detour to fix this long-standing annoyance in debugging Specimin.

I tested this change by sending SIGINT (by typing CTRL-C) to an infinite-looping Specimin process targeting the Checker Framework (i.e., my reproduction script for #272), and confirming that no temp files are left in the input directory.