### PR TITLE
Fix infinite loop when extending a class fails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,12 +58,12 @@ task expectedTestOutputsMustCompile(type: Exec) {
 
 tasks.compileJava {
     // uncomment for testing
-    options.errorprone.enabled = false
+    // options.errorprone.enabled = false
 }
 
 checkerFramework {
     // uncomment for testing
-    skipCheckerFramework = true
+    // skipCheckerFramework = true
     checkers = [
             'org.checkerframework.checker.nullness.NullnessChecker',
             'org.checkerframework.checker.resourceleak.ResourceLeakChecker',

--- a/build.gradle
+++ b/build.gradle
@@ -58,12 +58,12 @@ task expectedTestOutputsMustCompile(type: Exec) {
 
 tasks.compileJava {
     // uncomment for testing
-    // options.errorprone.enabled = false
+    options.errorprone.enabled = false
 }
 
 checkerFramework {
     // uncomment for testing
-    // skipCheckerFramework = true
+    skipCheckerFramework = true
     checkers = [
             'org.checkerframework.checker.nullness.NullnessChecker',
             'org.checkerframework.checker.resourceleak.ResourceLeakChecker',

--- a/cf-loop-bug.sh
+++ b/cf-loop-bug.sh
@@ -1,7 +1,0 @@
-# Reproduction script for https://github.com/kelloggm/specimin/issues/272
-
-## First attempt, doesn't repro with specimin main on 4/29/24 9:30am (crash reported, no crash observed)
-#./gradlew run --args='--outputDirectory "/Users/mjk76/Research/code-review-verification/playground/cf-out" --root "/Users/mjk76/jsr308/checker-framework/framework/src/main/java" --targetFile "org/checkerframework/framework/util/typeinference8/types/AbstractType.java" --targetMethod "org.checkerframework.framework.util.typeinference8.types.AbstractType#getFunctionTypeParameterTypes()"'
-
-## Attempt two
-./gradlew run --args='--outputDirectory "/Users/mjk76/Research/code-review-verification/playground/cf-out" --root "/Users/mjk76/jsr308/checker-framework/framework/src/main/java" --targetFile "org/checkerframework/framework/util/Contract.java" --targetMethod "org.checkerframework.framework.util.Contract#viewpointAdaptDependentTypeAnnotation(GenericAnnotatedTypeFactory<?,?,?,?>, StringToJavaExpression, Tree)"'

--- a/cf-loop-bug.sh
+++ b/cf-loop-bug.sh
@@ -1,0 +1,7 @@
+# Reproduction script for https://github.com/kelloggm/specimin/issues/272
+
+## First attempt, doesn't repro with specimin main on 4/29/24 9:30am (crash reported, no crash observed)
+#./gradlew run --args='--outputDirectory "/Users/mjk76/Research/code-review-verification/playground/cf-out" --root "/Users/mjk76/jsr308/checker-framework/framework/src/main/java" --targetFile "org/checkerframework/framework/util/typeinference8/types/AbstractType.java" --targetMethod "org.checkerframework.framework.util.typeinference8.types.AbstractType#getFunctionTypeParameterTypes()"'
+
+## Attempt two
+./gradlew run --args='--outputDirectory "/Users/mjk76/Research/code-review-verification/playground/cf-out" --root "/Users/mjk76/jsr308/checker-framework/framework/src/main/java" --targetFile "org/checkerframework/framework/util/Contract.java" --targetMethod "org.checkerframework.framework.util.Contract#viewpointAdaptDependentTypeAnnotation(GenericAnnotatedTypeFactory<?,?,?,?>, StringToJavaExpression, Tree)"'

--- a/src/main/java/org/checkerframework/specimin/EnumVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/EnumVisitor.java
@@ -84,7 +84,6 @@ public class EnumVisitor extends VoidVisitorAdapter<Void> {
       boolean oldInsideTargetMethod = insideTargetMethod;
       insideTargetMethod = true;
       super.visit(methodDeclaration, arg);
-      insideTargetMethod = false;
       insideTargetMethod = oldInsideTargetMethod;
     }
     // no need to visit non-target methods.
@@ -135,6 +134,7 @@ public class EnumVisitor extends VoidVisitorAdapter<Void> {
 
     if (resolvedField.isEnumConstant()) {
       ResolvedType correspondingEnumDeclaration = resolvedField.asEnumConstant().getType();
+      System.out.println("adding to used enum: " + correspondingEnumDeclaration.describe());
       usedEnum.add(correspondingEnumDeclaration.describe());
     }
   }

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -379,6 +379,9 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
       // utilized. It's not surprising for unused members to remain unresolved.
       // If this constructor is from the parent of the current class, and it is not resolved, we
       // will get a RuntimeException, otherwise just a UnsolvedSymbolException.
+      System.out.println(
+          "removing " + constructorDecl.getDeclarationAsString() + " because it is unsolvable");
+      System.out.println(e);
       constructorDecl.remove();
       return constructorDecl;
     }

--- a/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/PrunerVisitor.java
@@ -544,7 +544,7 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
   }
 
   /**
-   * Given a NodeList of types, this method removes those type not used by target methods.
+   * Given a NodeList of types, this method removes those types not used by target methods.
    *
    * @param inputList a NodeList of ClassOrInterfaceType instances.
    * @return the updated list with unused types removed.
@@ -556,7 +556,7 @@ public class PrunerVisitor extends ModifierVisitor<Void> {
       ResolvedType resolvedType;
       try {
         resolvedType = type.resolve();
-      } catch (UnsolvedSymbolException e) {
+      } catch (UnsolvedSymbolException | IllegalStateException e) {
         continue;
       }
       if (classesUsedByTargetMethods.contains(resolvedType.asReferenceType().getQualifiedName())) {

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -266,10 +266,6 @@ public class SpeciminRunner {
       boolean gettingStuck =
           workDoneAfterIteration.equals(workDoneBeforeIteration)
               && addMissingClass.gettingException();
-      System.out.println("getting stuck? " + gettingStuck);
-      System.out.println("getting exception? " + addMissingClass.gettingException());
-      System.out.println(
-          "making progress? " + workDoneAfterIteration.equals(workDoneBeforeIteration));
       if (gettingStuck || !addMissingClass.gettingException()) {
         // Three possible cases here:
         // 1: addMissingClass has finished its iteration.
@@ -291,14 +287,11 @@ public class SpeciminRunner {
             new JavaTypeCorrect(root, new HashSet<>(targetFiles), filesAndAssociatedTypes);
         typeCorrecter.correctTypesForAllFiles();
         typesToChange = typeCorrecter.getTypeToChange();
-        System.out.println("types to change: " + typesToChange);
-        System.out.println("types to extend: " + typeCorrecter.getExtendedTypes());
         classAndUnresolvedInterface = typeCorrecter.getClassAndUnresolvedInterface();
         boolean changeAtLeastOneType = addMissingClass.updateTypes(typesToChange);
         boolean extendAtLeastOneType =
             addMissingClass.updateTypesWithExtends(typeCorrecter.getExtendedTypes());
         boolean atLeastOneTypeIsUpdated = changeAtLeastOneType || extendAtLeastOneType;
-        System.out.println("at least one type updated: " + atLeastOneTypeIsUpdated);
 
         // this is case 2. We will stop addMissingClass. In the next phase,
         // TargetMethodFinderVisitor will give us a meaningful exception message regarding which

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -225,6 +225,7 @@ public class SpeciminRunner {
       boolean gettingStuck =
           workDoneAfterIteration.equals(workDoneBeforeIteration)
               && addMissingClass.gettingException();
+      System.out.println("work done after iteration: " + workDoneAfterIteration);
       if (gettingStuck || !addMissingClass.gettingException()) {
         // Three possible cases here:
         // 1: addMissingClass has finished its iteration.

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -261,7 +261,11 @@ public class SpeciminRunner {
       boolean gettingStuck =
           workDoneAfterIteration.equals(workDoneBeforeIteration)
               && addMissingClass.gettingException();
-      System.out.println("work done after iteration: " + workDoneAfterIteration);
+      System.out.println(
+          "work done after iteration not changing? "
+              + workDoneAfterIteration.equals(workDoneBeforeIteration));
+      System.out.println("getting exception? " + addMissingClass.gettingException());
+      System.out.println("getting stuck? " + gettingStuck);
       if (gettingStuck || !addMissingClass.gettingException()) {
         // Three possible cases here:
         // 1: addMissingClass has finished its iteration.
@@ -283,6 +287,10 @@ public class SpeciminRunner {
             new JavaTypeCorrect(root, new HashSet<>(targetFiles), filesAndAssociatedTypes);
         typeCorrecter.correctTypesForAllFiles();
         typesToChange = typeCorrecter.getTypeToChange();
+        System.out.println("types to change: " + typesToChange);
+        System.out.println("types to extend: " + typeCorrecter.getExtendedTypes());
+        System.out.println(
+            "class and unresolved interface: " + typeCorrecter.getClassAndUnresolvedInterface());
         classAndUnresolvedInterface = typeCorrecter.getClassAndUnresolvedInterface();
         boolean changeAtLeastOneType = addMissingClass.updateTypes(typesToChange);
         boolean extendAtLeastOneType =

--- a/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
+++ b/src/main/java/org/checkerframework/specimin/SpeciminRunner.java
@@ -266,6 +266,10 @@ public class SpeciminRunner {
       boolean gettingStuck =
           workDoneAfterIteration.equals(workDoneBeforeIteration)
               && addMissingClass.gettingException();
+      System.out.println("getting stuck? " + gettingStuck);
+      System.out.println("getting exception? " + addMissingClass.gettingException());
+      System.out.println(
+          "making progress? " + workDoneAfterIteration.equals(workDoneBeforeIteration));
       if (gettingStuck || !addMissingClass.gettingException()) {
         // Three possible cases here:
         // 1: addMissingClass has finished its iteration.
@@ -287,11 +291,14 @@ public class SpeciminRunner {
             new JavaTypeCorrect(root, new HashSet<>(targetFiles), filesAndAssociatedTypes);
         typeCorrecter.correctTypesForAllFiles();
         typesToChange = typeCorrecter.getTypeToChange();
+        System.out.println("types to change: " + typesToChange);
+        System.out.println("types to extend: " + typeCorrecter.getExtendedTypes());
         classAndUnresolvedInterface = typeCorrecter.getClassAndUnresolvedInterface();
         boolean changeAtLeastOneType = addMissingClass.updateTypes(typesToChange);
         boolean extendAtLeastOneType =
             addMissingClass.updateTypesWithExtends(typeCorrecter.getExtendedTypes());
         boolean atLeastOneTypeIsUpdated = changeAtLeastOneType || extendAtLeastOneType;
+        System.out.println("at least one type updated: " + atLeastOneTypeIsUpdated);
 
         // this is case 2. We will stop addMissingClass. In the next phase,
         // TargetMethodFinderVisitor will give us a meaningful exception message regarding which

--- a/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/TargetMethodFinderVisitor.java
@@ -35,6 +35,7 @@ import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclar
 import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
+import com.github.javaparser.resolution.types.ResolvedWildcard;
 import com.google.common.base.Splitter;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -878,7 +879,16 @@ public class TargetMethodFinderVisitor extends ModifierVisitor<Void> {
     ResolvedReferenceType typeAsReference = type.asReferenceType();
     List<ResolvedType> typeParameters = typeAsReference.typeParametersValues();
     for (ResolvedType typePara : typeParameters) {
-      if (typePara.isPrimitive() || typePara.isTypeVariable() || typePara.isWildcard()) {
+      if (typePara.isPrimitive() || typePara.isTypeVariable()) {
+        // Nothing to do, since these are already in-scope.
+        continue;
+      }
+      if (typePara.isWildcard()) {
+        ResolvedWildcard asWildcard = typePara.asWildcard();
+        // Recurse into the bound, if one exists.
+        if (asWildcard.isBounded()) {
+          updateUsedClassBasedOnType(asWildcard.getBoundedType());
+        }
         continue;
       }
       updateUsedClassWithQualifiedClassName(

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -1059,6 +1059,18 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
     // target method.
     boolean oldInsideTargetMember = insideTargetMember;
     insideTargetMember = true;
+    // Enum constants always have an enum as their parent.
+    //    EnumDeclaration parent = (EnumDeclaration) expr.getParentNode().get();
+    //    String type = parent.getNameAsString();
+    //    try {
+    //      List<String> argumentsCreation =
+    //          getArgumentTypesImpl(expr.getArguments(), getPackageFromClassName(type));
+    //      UnsolvedMethod creationMethod = new UnsolvedMethod("", type, argumentsCreation);
+    //      updateUnsolvedClassWithClassName(type, false, false, creationMethod);
+    //    } catch (Exception q) {
+    //      // can not solve the parameters for this object creation in this current run
+    //      gotException();
+    //    }
     Visitable result = super.visit(expr, p);
     insideTargetMember = oldInsideTargetMember;
     return result;

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -3085,7 +3085,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
         // of Javac
         if (typeToExtend.equals(missedClass.getQualifiedClassName())
             || typeToExtend.equals(missedClass.getClassName())) {
-          atLeastOneTypeIsUpdated = true;
+
+          String missedClassBefore = missedClass.toString();
+
           iterator.remove();
 
           // Special case: if the type to extend is "Annotation", then change the
@@ -3102,6 +3104,9 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
           modifiedClasses.add(missedClass);
           this.deleteOldSyntheticClass(missedClass);
           this.createMissingClass(missedClass);
+          // Only count an update if the text of the synthetic class changes, to avoid infinite
+          // loops.
+          atLeastOneTypeIsUpdated |= (!missedClassBefore.equals(missedClass.toString()));
         }
       }
     }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -3106,7 +3106,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
           this.createMissingClass(missedClass);
           // Only count an update if the text of the synthetic class changes, to avoid infinite
           // loops.
-          atLeastOneTypeIsUpdated |= (!missedClassBefore.equals(missedClass.toString()));
+          atLeastOneTypeIsUpdated |= !missedClassBefore.equals(missedClass.toString());
         }
       }
     }

--- a/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
+++ b/src/main/java/org/checkerframework/specimin/UnsolvedSymbolVisitor.java
@@ -92,7 +92,7 @@ public class UnsolvedSymbolVisitor extends ModifierVisitor<Void> {
    * Flag for whether or not to print debugging output. Should always be false except when you are
    * actively debugging.
    */
-  private static final boolean DEBUG = false;
+  private static final boolean DEBUG = true;
 
   /**
    * This map associates class names with their respective superclasses. The keys in this map

--- a/src/test/java/org/checkerframework/specimin/Issue272Test.java
+++ b/src/test/java/org/checkerframework/specimin/Issue272Test.java
@@ -10,9 +10,6 @@ public class Issue272Test {
     SpeciminTestExecutor.runTestWithoutJarPaths(
         "issue272",
         new String[] {"com/example/Simple.java"},
-        new String[] {
-          "com.example.Simple#viewpointAdaptDependentTypeAnnotation(GenericAnnotatedTypeFactory<?,?,?,?>,"
-              + " StringToJavaExpression, Tree)"
-        });
+        new String[] {"com.example.Simple#bar()"});
   }
 }

--- a/src/test/java/org/checkerframework/specimin/Issue272Test.java
+++ b/src/test/java/org/checkerframework/specimin/Issue272Test.java
@@ -1,0 +1,18 @@
+package org.checkerframework.specimin;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** This test checks for an infinite loop. */
+public class Issue272Test {
+  @Test
+  public void runTest() throws IOException {
+    SpeciminTestExecutor.runTestWithoutJarPaths(
+        "issue272",
+        new String[] {"com/example/Simple.java"},
+        new String[] {
+          "com.example.Simple#viewpointAdaptDependentTypeAnnotation(GenericAnnotatedTypeFactory<?,?,?,?>,"
+              + " StringToJavaExpression, Tree)"
+        });
+  }
+}

--- a/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PostconditionAnnotation.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public @interface PostconditionAnnotation {
+
+}

--- a/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
+++ b/src/test/resources/issue272/expected/com/example/PreconditionAnnotation.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public @interface PreconditionAnnotation {
+
+}

--- a/src/test/resources/issue272/expected/com/example/Simple.java
+++ b/src/test/resources/issue272/expected/com/example/Simple.java
@@ -1,0 +1,13 @@
+package com.example;
+
+class Simple {
+
+    void bar() {
+        Object obj = new Object();
+        obj = baz(obj);
+    }
+
+    Object baz(Object obj) {
+        throw new Error();
+    }
+}

--- a/src/test/resources/issue272/expected/com/example/Simple.java
+++ b/src/test/resources/issue272/expected/com/example/Simple.java
@@ -1,13 +1,19 @@
 package com.example;
 
-class Simple {
+import java.lang.annotation.Annotation;
 
-    void bar() {
-        Object obj = new Object();
-        obj = baz(obj);
+public class Simple {
+
+    public enum Kind {
+        PRECONDITION(PreconditionAnnotation.class), POSTCONDITION(PostconditionAnnotation.class);
+
+        Kind(Class<? extends Annotation> metaAnnotation) {
+            throw new Error();
+        }
     }
 
-    Object baz(Object obj) {
-        throw new Error();
+    public void bar() {
+        Kind kind = Kind.POSTCONDITION;
+        kind = Kind.PRECONDITION;
     }
 }

--- a/src/test/resources/issue272/input/com/example/Simple.java
+++ b/src/test/resources/issue272/input/com/example/Simple.java
@@ -1,32 +1,22 @@
 package com.example;
 
-import com.sun.source.tree.Tree;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import java.lang.annotation.Annotation;
 
-import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
-import org.checkerframework.framework.util.dependenttypes.DependentTypesHelper;
+public class Simple {
 
-import javax.lang.model.element.AnnotationMirror;
+    public enum Kind {
+        PRECONDITION(PreconditionAnnotation.class),
+        POSTCONDITION(PostconditionAnnotation.class);
 
-public abstract class Simple {
+        public final Class<? extends Annotation> metaAnnotation;
 
-    public final AnnotationMirror annotation;
-
-    // Target method. Note that StringToJavaExpression is an interface in the same package as
-    // the target method's class.
-    public AnnotationMirror viewpointAdaptDependentTypeAnnotation(
-            GenericAnnotatedTypeFactory<?, ?, ?, ?> factory,
-            StringToJavaExpression stringToJavaExpr,
-            @Nullable Tree errorTree) {
-        DependentTypesHelper dependentTypesHelper = factory.getDependentTypesHelper();
-        AnnotationMirror standardized =
-                dependentTypesHelper.convertAnnotationMirror(stringToJavaExpr, annotation);
-        if (standardized == null) {
-            return annotation;
+        Kind(Class<? extends Annotation> metaAnnotation) {
+            this.metaAnnotation = metaAnnotation;
         }
-        if (errorTree != null) {
-            dependentTypesHelper.checkAnnotationForErrorExpressions(standardized, errorTree);
-        }
-        return standardized;
+    }
+
+    public void bar() {
+        Kind kind = Kind.POSTCONDITION;
+        kind = Kind.PRECONDITION;
     }
 }

--- a/src/test/resources/issue272/input/com/example/Simple.java
+++ b/src/test/resources/issue272/input/com/example/Simple.java
@@ -1,0 +1,32 @@
+package com.example;
+
+import com.sun.source.tree.Tree;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
+import org.checkerframework.framework.util.dependenttypes.DependentTypesHelper;
+
+import javax.lang.model.element.AnnotationMirror;
+
+public abstract class Simple {
+
+    public final AnnotationMirror annotation;
+
+    // Target method. Note that StringToJavaExpression is an interface in the same package as
+    // the target method's class.
+    public AnnotationMirror viewpointAdaptDependentTypeAnnotation(
+            GenericAnnotatedTypeFactory<?, ?, ?, ?> factory,
+            StringToJavaExpression stringToJavaExpr,
+            @Nullable Tree errorTree) {
+        DependentTypesHelper dependentTypesHelper = factory.getDependentTypesHelper();
+        AnnotationMirror standardized =
+                dependentTypesHelper.convertAnnotationMirror(stringToJavaExpr, annotation);
+        if (standardized == null) {
+            return annotation;
+        }
+        if (errorTree != null) {
+            dependentTypesHelper.checkAnnotationForErrorExpressions(standardized, errorTree);
+        }
+        return standardized;
+    }
+}

--- a/src/test/resources/issue272/input/com/example/StringToJavaExpression.java
+++ b/src/test/resources/issue272/input/com/example/StringToJavaExpression.java
@@ -1,0 +1,6 @@
+package com.example;
+
+@FunctionalInterface
+public interface StringToJavaExpression {
+
+}

--- a/src/test/resources/issue272/input/com/example/StringToJavaExpression.java
+++ b/src/test/resources/issue272/input/com/example/StringToJavaExpression.java
@@ -1,6 +1,0 @@
-package com.example;
-
-@FunctionalInterface
-public interface StringToJavaExpression {
-
-}


### PR DESCRIPTION
Review and merge after #274 (includes the changes in that PR). Fixes the infinite loop in #272.

I was not able to find a minimal test case for this bug, unfortunately. I've confirmed that Specimin now terminates on the following input, which #272 reported caused an infinite loop and which I could repro locally:
```
--outputDirectory "/my/temp/dir" --root "/my/root/checker-framework/framework/src/main/java" --targetFile "org/checkerframework/framework/util/Contract.java" --targetMethod "org.checkerframework.framework.util.Contract#viewpointAdaptDependentTypeAnnotation(GenericAnnotatedTypeFactory<?,?,?,?>, StringToJavaExpression, Tree)"
```